### PR TITLE
[irods/irods#3991] Set spOption everywhere (4-2-stable)

### DIFF
--- a/src/iapitest.cpp
+++ b/src/iapitest.cpp
@@ -30,13 +30,20 @@ typedef struct {
     otherOut_t _other;
 } helloOut_t;
 
-void usage();
-
 int
-main( int, char** ) {
+main( int argc, char** argv ) {
 
     signal( SIGPIPE, SIG_IGN );
 
+    if (NULL != argv && NULL != argv[0]) {
+        /* set SP_OPTION to argv[0] so it can be passed to server */
+        char child[MAX_NAME_LEN], parent[MAX_NAME_LEN];
+        *child = '\0';
+        splitPathByKey(argv[0], parent, MAX_NAME_LEN, child, MAX_NAME_LEN, '/');
+        if (*child != '\0') {
+            mySetenvStr(SP_OPTION, child);
+        }
+    }
 
     rodsEnv myEnv;
     int status = getRodsEnv( &myEnv );

--- a/src/iclienthints.cpp
+++ b/src/iclienthints.cpp
@@ -36,7 +36,7 @@ void usage() {
 }
 
 int
-main( int _argc, char** ) {
+main( int _argc, char** argv ) {
 
     signal( SIGPIPE, SIG_IGN );
 
@@ -45,8 +45,20 @@ main( int _argc, char** ) {
         return 0;
     }
 
+    rodsArguments_t myRodsArgs;
+    char* optStr = "h";
+    int status = parseCmdLineOpt(_argc, argv, optStr, 0, &myRodsArgs);
+    if (status) {
+        printf("Use -h for help.\n");
+        exit(1);
+    }
+    if (True == myRodsArgs.help) {
+        usage();
+        exit(0);
+    }
+
     rodsEnv myEnv;
-    int status = getRodsEnv( &myEnv );
+    status = getRodsEnv( &myEnv );
     if ( status < 0 ) {
         rodsLogError( LOG_ERROR, status, "main: getRodsEnv error. " );
         exit( 1 );

--- a/src/izonereport.cpp
+++ b/src/izonereport.cpp
@@ -39,7 +39,7 @@ void usage() {
 }
 
 int
-main( int _argc, char** ) {
+main( int _argc, char** argv ) {
 
     signal( SIGPIPE, SIG_IGN );
 
@@ -48,8 +48,20 @@ main( int _argc, char** ) {
         return 0;
     }
 
+    rodsArguments_t myRodsArgs;
+    char* optStr = "h";
+    int status = parseCmdLineOpt(_argc, argv, optStr, 0, &myRodsArgs);
+    if (status) {
+        printf("Use -h for help.\n");
+        exit(1);
+    }
+    if (True == myRodsArgs.help) {
+        usage();
+        exit(0);
+    }
+
     rodsEnv myEnv;
-    int status = getRodsEnv( &myEnv );
+    status = getRodsEnv( &myEnv );
     if ( status < 0 ) {
         rodsLogError( LOG_ERROR, status, "main: getRodsEnv error. " );
         exit( 1 );


### PR DESCRIPTION
spOption is the environment variable that the server checks to identify a connected client. This variable should be set for all the icommands. izonereport, iapitest, and iclienthints do not set this environment
variable. In the case of izonereport and iclienthints, the -h flag was actually not supported at all, despite claiming to have support.

(cherry-picked from SHA: 008b5343e086e452cbf62173d94fc4f8fbafd05a)

---
[Passed CI tests.](http://172.25.14.125:8080/job/irods-build-and-test-workflow/1097/)