### PR TITLE
[#64] Removed std::auto_ptr so that project builds using C++17.

### DIFF
--- a/src/irods-grid.cpp
+++ b/src/irods-grid.cpp
@@ -208,7 +208,7 @@ irods::error prepare_command_for_transport(
         _env.irodsCtrlPlaneEncryptionAlgorithm );
 
     // serialize using the generated avro class
-    std::auto_ptr< avro::OutputStream > out = avro::memoryOutputStream();
+    auto out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::binaryEncoder();
     e->init( *out );
     avro::encode( *e, _cmd );


### PR DESCRIPTION
Depends on:  [irods/externals#15]

std::auto_ptr was removed from the C++17 standard.

Passed CI.