### PR TITLE
[irods/irods#4194] Honor zone name in iuserinfo (master)

### DIFF
--- a/src/iuserinfo.cpp
+++ b/src/iuserinfo.cpp
@@ -10,10 +10,8 @@
 #include "irods_client_api_table.hpp"
 #include "irods_pack_table.hpp"
 
-#define MAX_SQL 300
-#define BIG_STR 200
-
-char cwd[BIG_STR];
+#include "irods_query.hpp"
+#include <boost/format.hpp>
 
 int debug = 0;
 
@@ -22,172 +20,86 @@ rodsEnv myEnv;
 
 void usage();
 
-/*
- print the results of a general query.
- */
-int
-printGenQueryResults( rcComm_t *Conn, int status, genQueryOut_t *genQueryOut,
-                      char *descriptions[] ) {
-    int printCount;
-    int i, j;
-    char localTime[TIME_LEN];
-    printCount = 0;
-    if ( status != 0 ) {
-        printError( Conn, status, "rcGenQuery" );
-    }
-    else {
-        if ( status != CAT_NO_ROWS_FOUND ) {
-            for ( i = 0; i < genQueryOut->rowCnt; i++ ) {
-                for ( j = 0; j < genQueryOut->attriCnt; j++ ) {
-                    char *tResult;
-                    tResult = genQueryOut->sqlResult[j].value;
-                    tResult += i * genQueryOut->sqlResult[j].len;
-                    if ( strstr( descriptions[j], "time" ) != 0 ) {
-                        getLocalTimeFromRodsTime( tResult, localTime );
-                        printf( "%s: %s: %s\n", descriptions[j], tResult,
-                                localTime );
-                    }
-                    else {
-                        printf( "%s: %s\n", descriptions[j], tResult );
-                    }
-                    printCount++;
-                }
-            }
-        }
-    }
-    return printCount;
+struct userinfo_t {
+    char* user_name;
+    char* zone_name;
+};
+
+std::string construct_userinfo_query_string(
+    const userinfo_t& _info,
+    const std::string& _select_string) {
+    return std::string{(boost::format("SELECT %s WHERE USER_NAME = '%s' AND USER_ZONE = '%s'") %
+                        _select_string % _info.user_name % _info.zone_name).str()};
 }
 
-/*
-Via a general query, show user information
-*/
+bool print_general_info(const userinfo_t& _info) {
+    // Construct query object for listing info for specified user
+    const std::string select{
+        "USER_NAME, USER_ID, USER_TYPE, USER_ZONE, USER_INFO, USER_COMMENT, USER_CREATE_TIME, USER_MODIFY_TIME"};
+    irods::query qobj{Conn, construct_userinfo_query_string(_info, select)};
+
+    // Ensure that user exists
+    if (qobj.begin() == qobj.end()) {
+        return false;
+    }
+
+    // Print information concerning found users
+    const std::vector<std::string> general_info_labels{
+        "name", "id", "type", "zone", "info", "comment", "create time", "modify time"};
+    int i{};
+    for (const auto& selections: *qobj.begin()) {
+        if (std::string::npos != (general_info_labels[i].find("time"))) {
+            char local_time[TIME_LEN]{};
+            getLocalTimeFromRodsTime(selections.c_str(), local_time);
+            printf("%s: %s: %s\n", general_info_labels[i].c_str(), selections.c_str(), local_time);
+        }
+        else {
+            printf("%s: %s\n", general_info_labels[i].c_str(), selections.c_str());
+        }
+        i++;
+    }
+    return true;
+}
+
+void print_auth_info(const userinfo_t& _info) {
+    irods::query qobj{Conn, construct_userinfo_query_string(_info, "USER_DN")};
+    for (const auto& result: qobj) {
+        printf("GSI DN or Kerberos Principal Name: %s\n", result[0].c_str());
+    }
+}
+
+void print_group_info(const userinfo_t& _info) {
+    irods::query qobj{Conn, construct_userinfo_query_string(_info, "USER_GROUP_NAME")};
+    if (qobj.begin() == qobj.end()) {
+        printf("Not a member of any group\n");
+        return;
+    }
+
+    for (const auto& result: qobj) {
+        printf("member of group: %s\n", result[0].c_str());
+    }
+}
+
 int
-showUser( char *name ) {
-    genQueryInp_t genQueryInp;
-    genQueryOut_t *genQueryOut;
-    int i1a[20];
-    int i1b[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    int i2a[20];
-    char *condVal[10];
-    char v1[BIG_STR];
-    int i, status;
-    int printCount;
-    char *columnNames[] = {"name", "id", "type", "zone", "info", "comment",
-                           "create time", "modify time"
-                          };
-
-    char *columnNames2[] = {"member of group"};
-    char *columnNames3[] = {"GSI DN or Kerberos Principal Name"};
-
-    memset( &genQueryInp, 0, sizeof( genQueryInp_t ) );
-    printCount = 0;
-    i = 0;
-    i1a[i++] = COL_USER_NAME;
-    i1a[i++] = COL_USER_ID;
-    i1a[i++] = COL_USER_TYPE;
-    i1a[i++] = COL_USER_ZONE;
-    i1a[i++] = COL_USER_INFO;
-    i1a[i++] = COL_USER_COMMENT;
-    i1a[i++] = COL_USER_CREATE_TIME;
-    i1a[i++] = COL_USER_MODIFY_TIME;
-    genQueryInp.selectInp.inx = i1a;
-    genQueryInp.selectInp.value = i1b;
-    genQueryInp.selectInp.len = i;
-
-    i2a[0] = COL_USER_NAME;
-    snprintf( v1, BIG_STR, "='%s'", name );
-    condVal[0] = v1;
-
-    genQueryInp.sqlCondInp.inx = i2a;
-    genQueryInp.sqlCondInp.value = condVal;
-    genQueryInp.sqlCondInp.len = 1;
-
-    genQueryInp.condInput.len = 0;
-
-    genQueryInp.maxRows = 2;
-    genQueryInp.continueInx = 0;
-    status = rcGenQuery( Conn, &genQueryInp, &genQueryOut );
-    if ( status == CAT_NO_ROWS_FOUND ) {
-        i1a[0] = COL_USER_COMMENT;
-        genQueryInp.selectInp.len = 1;
-        status = rcGenQuery( Conn, &genQueryInp, &genQueryOut );
-        if ( status == 0 ) {
-            printf( "None\n" );
-            return 0;
-        }
-        if ( status == CAT_NO_ROWS_FOUND ) {
-            printf( "User %s does not exist.\n", name );
-            return 0;
-        }
+showUser(const char *name) {
+    char user_name[NAME_LEN]{};
+    char zone_name[NAME_LEN]{};
+    int status = parseUserName(name, user_name, zone_name);
+    if (status < 0) {
+        printf("Failed parsing input:[%s]\n", name);
+        return status;
     }
-
-    printCount += printGenQueryResults( Conn, status, genQueryOut, columnNames );
-
-
-    printCount = 0;
-    i1a[0] = COL_USER_DN;
-    genQueryInp.selectInp.inx = i1a;
-    genQueryInp.selectInp.value = i1b;
-    genQueryInp.selectInp.len = 1;
-
-    i2a[0] = COL_USER_NAME;
-    snprintf( v1, BIG_STR, "='%s'", name );
-    condVal[0] = v1;
-
-    genQueryInp.sqlCondInp.inx = i2a;
-    genQueryInp.sqlCondInp.value = condVal;
-    genQueryInp.sqlCondInp.len = 1;
-
-    genQueryInp.condInput.len = 0;
-
-    genQueryInp.maxRows = 50;
-    genQueryInp.continueInx = 0;
-    status = rcGenQuery( Conn, &genQueryInp, &genQueryOut );
-    if ( status == CAT_NO_ROWS_FOUND ) {
+    if (std::string(zone_name).empty()) {
+        snprintf(zone_name, sizeof(zone_name), "%s", myEnv.rodsZone);
     }
-    else {
-        printCount += printGenQueryResults( Conn, status, genQueryOut,
-                                            columnNames3 );
+    const userinfo_t info{user_name, zone_name};
 
-        while ( status == 0 && genQueryOut->continueInx > 0 ) {
-            genQueryInp.continueInx = genQueryOut->continueInx;
-            status = rcGenQuery( Conn, &genQueryInp, &genQueryOut );
-            printCount += printGenQueryResults( Conn, status, genQueryOut,
-                                                columnNames3 );
-        }
-    }
-
-    printCount = 0;
-    i1a[0] = COL_USER_GROUP_NAME;
-    genQueryInp.selectInp.inx = i1a;
-    genQueryInp.selectInp.value = i1b;
-    genQueryInp.selectInp.len = 1;
-
-    i2a[0] = COL_USER_NAME;
-    snprintf( v1, BIG_STR, "='%s'", name );
-    condVal[0] = v1;
-
-    genQueryInp.sqlCondInp.inx = i2a;
-    genQueryInp.sqlCondInp.value = condVal;
-    genQueryInp.sqlCondInp.len = 1;
-
-    genQueryInp.condInput.len = 0;
-
-    genQueryInp.maxRows = 50;
-    genQueryInp.continueInx = 0;
-    status = rcGenQuery( Conn, &genQueryInp, &genQueryOut );
-    if ( status == CAT_NO_ROWS_FOUND ) {
-        printf( "Not a member of any group\n" );
+    if (!print_general_info(info)) {
+        printf("User %s#%s does not exist.\n", info.user_name, info.zone_name);
         return 0;
     }
-    printCount += printGenQueryResults( Conn, status, genQueryOut, columnNames2 );
-
-    while ( status == 0 && genQueryOut->continueInx > 0 ) {
-        genQueryInp.continueInx = genQueryOut->continueInx;
-        status = rcGenQuery( Conn, &genQueryInp, &genQueryOut );
-        printCount += printGenQueryResults( Conn, status, genQueryOut,
-                                            columnNames2 );
-    }
+    print_auth_info(info);
+    print_group_info(info);
 
     return 0;
 }
@@ -244,16 +156,18 @@ main( int argc, char **argv ) {
     nArgs = argc - myRodsArgs.optind;
 
     if ( nArgs == 1 ) {
-        status = showUser( argv[myRodsArgs.optind] );
+        status = showUser(argv[myRodsArgs.optind]);
     }
     else {
-        status = showUser( myEnv.rodsUserName );
+        const auto user_name{(boost::format("%s#%s") %
+                              myEnv.rodsUserName % myEnv.rodsZone).str().c_str()};
+        status = showUser(user_name);
     }
 
     printErrorStack( Conn->rError );
     rcDisconnect( Conn );
 
-    exit( 0 );
+    exit( status );
 }
 
 /*


### PR DESCRIPTION
Refactor to use query iterator and recognize zone names. The client
has changed to follow these constraints:

 1. The current user is implied when there is no input
 2. The current zone is implied when no zone is supplied

In this way, each run of iuserinfo prints a unique user as users are
unique within zones.

---
[CI tests running](http://172.25.14.63:8080/view/Personal/job/irods-build-and-test-workflow/1752/)

Tests and query iterator changes in PR irods/irods#4242