### PR TITLE
[irods/irods#5214] iuserinfo: fix use after free in main (4-2-stable)

### DIFF
--- a/src/iuserinfo.cpp
+++ b/src/iuserinfo.cpp
@@ -159,9 +159,9 @@ main( int argc, char **argv ) {
         status = showUser(argv[myRodsArgs.optind]);
     }
     else {
-        const auto user_name{(boost::format("%s#%s") %
-                              myEnv.rodsUserName % myEnv.rodsZone).str().c_str()};
-        status = showUser(user_name);
+        const std::string user_name = (boost::format("%s#%s") %
+                                       myEnv.rodsUserName % myEnv.rodsZone).str();
+        status = showUser(user_name.c_str());
     }
 
     printErrorStack( Conn->rError );


### PR DESCRIPTION
Cherry-pick of #165

The data backing the pointer returned by `std::string::c_str()` only sticks around as long as the `std::string` object. In this case, the `std::string` object is only around long enough to return the pointer.

This also fixes a warning from clang 10.

Addresses irods/irods#5214