### PR TITLE
[irods/irods#5082] Introduce userspace tarball packaging functionality (master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 tags
 .dir-locals.el
+__pycache__
+*.pyc
+CMakeLists.txt.user
+*.wpr
+*.wpu
+.spyproject

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,26 @@
 cmake_minimum_required(VERSION 3.7.0 FATAL_ERROR) #CPACK_DEBIAN_<COMPONENT>_PACKAGE_NAME
 
 find_package(IRODS 4.3.0 EXACT REQUIRED CONFIG)
+set(IRODS_PACKAGE_PREFIX "${PACKAGE_PREFIX_DIR}")
 
 include(RequireOutOfSourceBuild)
 
-set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
 set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
 set(CMAKE_CXX_STANDARD 17)
+# export-dynamic so stacktrace entries from executables have function names
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-rdynamic -Wl,--export-dynamic -Wl,--enable-new-dtags -Wl,--as-needed -Wl,-z,defs")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE_INIT "-Wl,--gc-sections -Wl,-z,combreloc")
 
 project(icommands
   VERSION "${IRODS_VERSION}"
-  LANGUAGES C CXX)
+  LANGUAGES CXX)
+
+set(CMAKE_SKIP_BUILD_RPATH OFF)
+set(CMAKE_SKIP_INSTALL_RPATH OFF)
+set(CMAKE_SKIP_RPATH OFF)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
+set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 
 include(UseLibCXX)
 
@@ -97,6 +107,8 @@ endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter)
+
+add_custom_target(icommands)
 
 set(
   IRODS_CLIENT_ICOMMANDS_EXECUTABLES
@@ -185,11 +197,18 @@ foreach(EXECUTABLE ${IRODS_CLIENT_ICOMMANDS_EXECUTABLES})
     )
   target_compile_definitions(${EXECUTABLE} PRIVATE ${IRODS_COMPILE_DEFINITIONS} BOOST_SYSTEM_NO_DEPRECATED)
   target_compile_options(${EXECUTABLE} PRIVATE -Wno-write-strings)
+  if (CMAKE_VERSION VERSION_LESS "3.13.0")
+    set_property(TARGET ${EXECUTABLE} APPEND PROPERTY LINK_FLAGS "-Wl,-z,origin")
+  else()
+    target_link_options(${EXECUTABLE} PRIVATE "LINKER:-z,origin")
+  endif()
+  add_dependencies(icommands ${EXECUTABLE})
   install(
     TARGETS
     ${EXECUTABLE}
     RUNTIME
     DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT icommands
     )
 
   if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
@@ -222,6 +241,7 @@ foreach(EXECUTABLE ${IRODS_CLIENT_ICOMMANDS_EXECUTABLES})
       FILES
       ${EXECUTABLE_MANPAGE}.gz
       DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+      COMPONENT manpages
       )
   endif()
 endforeach()
@@ -238,6 +258,7 @@ foreach(IRODS_CLIENT_ICOMMANDS_SCRIPT ${IRODS_CLIENT_ICOMMANDS_SCRIPTS})
     ${SCRIPT_SRC_PATH}
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+    COMPONENT icommands
     )
 
   if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
@@ -266,6 +287,7 @@ foreach(IRODS_CLIENT_ICOMMANDS_SCRIPT ${IRODS_CLIENT_ICOMMANDS_SCRIPTS})
       FILES
       ${SCRIPT_MANPAGE}.gz
       DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+      COMPONENT manpages
       )
   endif()
 endforeach()
@@ -273,7 +295,116 @@ endforeach()
 install(
   DIRECTORY ${CMAKE_SOURCE_DIR}/test
   DESTINATION ${IRODS_HOME_DIRECTORY}/clients/icommands
+  COMPONENT testdata
   )
+
+
+if(NOT ICOMMANDS_USERSPACE_TARBALL_PLATFORM_NAME)
+  if(IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME)
+    set(ICOMMANDS_USERSPACE_TARBALL_PLATFORM_NAME "${IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME}")
+  elseif(IRODS_LINUX_DISTRIBUTION_NAME)
+    if(IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR AND NOT IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "none")
+      set(ICOMMANDS_USERSPACE_TARBALL_PLATFORM_NAME "${IRODS_LINUX_DISTRIBUTION_NAME}${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+    else()
+      set(ICOMMANDS_USERSPACE_TARBALL_PLATFORM_NAME "${IRODS_LINUX_DISTRIBUTION_NAME}")
+    endif()
+  else()
+    set(ICOMMANDS_USERSPACE_TARBALL_PLATFORM_NAME "${CMAKE_SYSTEM_NAME}")
+  endif()
+endif()
+
+set(ICOMMANDS_USERSPACE_TARBALL_FILENAME
+    "irods-icommands-${icommands_VERSION}-${ICOMMANDS_USERSPACE_TARBALL_PLATFORM_NAME}-${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_BUILD_TYPE}.tar.gz"
+    CACHE STRING
+    "Filename of userspace tarball package to generate")
+set(ICOMMANDS_USERSPACE_TARBALL_ROOT_DIRNAME
+    "irods-icommands-${icommands_VERSION}"
+    CACHE STRING
+    "Name of userspace tarball package's root directory. Set to empty string to use the root of the tarball as the root directory.")
+
+set(ICOMMANDS_USERSPACE_TARBALL_PATH "${CMAKE_CURRENT_BINARY_DIR}/${ICOMMANDS_USERSPACE_TARBALL_FILENAME}")
+
+# fetch the parts of irods-runtime currently exposed
+set(irods_runtime_components "irods_client;irods_common;irods_plugin_dependencies;irods_server")
+foreach(irods_runtime_component ${irods_runtime_components})
+  unset(iimported_location)
+  get_target_property(iimported_location ${irods_runtime_component} LOCATION)
+  list(APPEND IRODS_RUNTIME_LIBRARY_PATHS "${iimported_location}")
+  unset(iimported_location)
+endforeach()
+
+file(
+  GLOB ICOMMANDS_USERSPACE_TARBALL_INSTRUMENTATION
+  LIST_DIRECTORIES false
+  "${CMAKE_CURRENT_SOURCE_DIR}/packaging/userspace/*"
+  )
+
+if(DEFINED IRODS_EXTERNALS_FULLPATH_ARCHIVE AND IS_DIRECTORY "${IRODS_EXTERNALS_FULLPATH_ARCHIVE}/bin")
+  # Make septenvigintuple sure IRODS_EXTERNALS_FULLPATH_ARCHIVE doesn't point to the system
+  get_filename_component(_irods_libarchive_prefix "${IRODS_EXTERNALS_FULLPATH_ARCHIVE}" ABSOLUTE)
+  if(NOT _irods_libarchive_prefix MATCHES "^/(usr(/|/local/?)?)?$")
+    # don't cache results
+    find_program(
+      TMP_IC_UP_BSDTAR
+      NAMES bsdtar
+      PATHS "${_irods_libarchive_prefix}/bin"
+      NO_DEFAULT_PATH
+      )
+    set(IC_UP_BSDTAR "${TMP_IC_UP_BSDTAR}")
+    unset(TMP_IC_UP_BSDTAR CACHE)
+
+    if(IS_DIRECTORY "${_irods_libarchive_prefix}/lib")
+      # Make sure we actually found bsdtar in the extern prefix
+      get_filename_component(_found_bsdtar_bindir "${IC_UP_BSDTAR}" DIRECTORY)
+      if(_found_bsdtar_bindir STREQUAL "${_irods_libarchive_prefix}/bin")
+        # LD_LIBRARY_PATH for bsdtar in libarchive prefix
+        set(IC_UP_BSDTAR_LD_PATH "${_irods_libarchive_prefix}/lib")
+      endif()
+      unset(_found_bsdtar_bindir)
+    endif()
+
+  endif()
+  unset(_irods_libarchive_prefix)
+endif()
+
+add_custom_command(
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/packaging/userspace/userspace-packager.py" -v
+    "--cmake-path=${CMAKE_COMMAND}"
+    "$<$<BOOL:${CMAKE_OBJDUMP}>:--objdump-path=${CMAKE_OBJDUMP}>"
+    "$<$<BOOL:${CMAKE_READELF}>:--readelf-path=${CMAKE_READELF}>"
+    "$<$<BOOL:${CMAKE_STRIP}>:--strip-path=${CMAKE_STRIP}>"
+    "$<$<BOOL:${IC_UP_BSDTAR}>:--tar-path=${IC_UP_BSDTAR}>"
+    "$<$<BOOL:${IC_UP_BSDTAR_LD_PATH}>:--ld_library_path=${IC_UP_BSDTAR_LD_PATH}>"
+    "$<$<BOOL:${IRODS_LINUX_DISTRIBUTION_NAME}>:--target-platform=${IRODS_LINUX_DISTRIBUTION_NAME}>"
+    "$<$<BOOL:${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}>:--target-platform-variant=${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}>"
+    "--cmake-install-prefix=${CMAKE_INSTALL_PREFIX}"
+    "--cmake-install-bindir=${CMAKE_INSTALL_BINDIR}"
+    "--cmake-install-sbindir=${CMAKE_INSTALL_SBINDIR}"
+    "--cmake-install-libdir=${CMAKE_INSTALL_LIBDIR}"
+    "--irods-package-prefix=${IRODS_PACKAGE_PREFIX}"
+    "--irods-install-prefix=${IRODS_INSTALL_PREFIX}"
+    "--irods-install-bindir=${IRODS_INSTALL_BINDIR}"
+    "--irods-install-sbindir=${IRODS_INSTALL_SBINDIR}"
+    "--irods-install-libdir=${IRODS_INSTALL_LIBDIR}"
+    "--irods-home-dir=${IRODS_HOME_DIRECTORY}"
+    "--irods-pluginsdir=${IRODS_PLUGINS_DIRECTORY}"
+    "$<$<BOOL:${CMAKE_SHARED_LIBRARY_SUFFIX}>:--sharedlib-suffix=${CMAKE_SHARED_LIBRARY_SUFFIX}>"
+    "$<$<BOOL:${CMAKE_EXTRA_SHARED_LIBRARY_SUFFIXES}>:--sharedlib-suffix=$<JOIN:${CMAKE_EXTRA_SHARED_LIBRARY_SUFFIXES},;--sharedlib-suffix=>>"
+    "$<$<BOOL:${IRODS_RUNTIME_LIBRARY_PATHS}>:--irods-runtime-lib=$<JOIN:${IRODS_RUNTIME_LIBRARY_PATHS},;--irods-runtime-lib=>>"
+    "$<$<BOOL:${LIBCXX_LIBRARIES}>:--libcxx-libpath=$<JOIN:${LIBCXX_LIBRARIES},;--libcxx-libpath=>>"
+    "--build-dir=${CMAKE_CURRENT_BINARY_DIR}"
+    "--work-dir=${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/userspace-tarball"
+    "--cmake-tmpdir=${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp"
+    "--install-component=icommands"
+    "$<$<BOOL:${IRODS_CLIENT_ICOMMANDS_SCRIPTS}>:--script-icommand=$<JOIN:${IRODS_CLIENT_ICOMMANDS_SCRIPTS},;--script-icommand=>>"
+    "$<$<BOOL:${ICOMMANDS_USERSPACE_TARBALL_ROOT_DIRNAME}>:--tarball-root-dir-name=${ICOMMANDS_USERSPACE_TARBALL_ROOT_DIRNAME}>"
+    "--output=${ICOMMANDS_USERSPACE_TARBALL_PATH}"
+  DEPENDS icommands "${ICOMMANDS_USERSPACE_TARBALL_INSTRUMENTATION}"
+  OUTPUT "${ICOMMANDS_USERSPACE_TARBALL_PATH}"
+  JOB_POOL console
+  COMMAND_EXPAND_LISTS
+  )
+add_custom_target(userspace-tarball DEPENDS "${ICOMMANDS_USERSPACE_TARBALL_PATH}")
 
 
 if (NOT CPACK_DEBIAN_PACKAGE_VERSION)

--- a/README.md
+++ b/README.md
@@ -34,3 +34,31 @@ Our dependency chain will shorten as older distributions age out.
 
 The current setup supports new C++ features on those older distributions.
 
+## Userspace Packaging
+
+A `userspace-tarball` buildsystem target is provided to generate a userspace tarball package. This package
+will contain the iCommands and all required library dependencies.
+See `packaging/userspace/build_and_package.example.sh` for an example of how to build and package the
+iCommands for userspace deployment.
+
+### Build Dependencies
+
+The userspace packager needs a few extra packages to work properly:
+- Required: Python 3.6+.
+- Required: `setuptools` Python 3 package.
+    - Available as `python3-setuptools` via yum/apt on Centos 7/Ubuntu.
+    - Available as `setuptools` on PyPI.
+- Recommended: `distro` Python 3 module.
+    - Required for Python 3.8+.
+    - Available as `python3-distro` via apt on Ubuntu 18.04+.
+    - Available as `python36-distro` via yum on Centos 7.
+    - Available as `distro` on PyPI.
+- Recommended: `lief` Python 3 module, version 0.10.0+ (preferably 0.11.0+).
+    - Available as `lief` on PyPI.
+- Recommended: `chrpath` tool
+    - Available as `chrpath` via yum/apt on Centos/Ubuntu.
+
+If you've got `pip`, the following one-liner should get all the Python dependencies installed:
+```sh
+python3 -m pip install lief setuptools distro
+```

--- a/packaging/userspace/build_and_package.example.sh
+++ b/packaging/userspace/build_and_package.example.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Example build script. Tweak as needed.
+set -e
+set -x
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" # directory containing this script
+
+ICOMMANDS_SRC_DIR="$(readlink -s -m "${ICOMMANDS_SRC_DIR:-"${SCRIPTDIR}/../.."}")" # icommands source directory
+ICOMMANDS_BLD_DIR="$(readlink -s -m "${ICOMMANDS_BLD_DIR:-"${ICOMMANDS_SRC_DIR}/../icommands_build/userspace"}")"
+
+IRODS_SRC_DIR="$(readlink -s -m "${IRODS_SRC_DIR:-"${ICOMMANDS_SRC_DIR}/../irods_source"}")" # irods source directory
+IRODS_BLD_DIR="$(readlink -s -m "${IRODS_BLD_DIR:-"${ICOMMANDS_BLD_DIR}/irods_build"}")" # irods build directory
+
+IRODS_BUILD_PREFIX="$(readlink -s -m "${IRODS_BUILD_PREFIX:-"${IRODS_BLD_DIR}/pfx"}")" # temporary install prefix
+
+QTY_CPUS="$(nproc --all)"
+QTY_JOBS="${QTY_JOBS:-"$(( ( QTY_CPUS > 1 ? QTY_CPUS : 2 ) * 2 / 3 ))"}"
+
+CMAKE="${CMAKE:-cmake}"
+IRODS_BUILD_CONFIGURATION="${BUILD_CONFIGURATION:-Release}"
+
+## Prepare workspace
+
+if [ ! -d "${ICOMMANDS_BLD_DIR}" ]; then
+	mkdir "${ICOMMANDS_BLD_DIR}"
+fi
+
+if [ ! -d "${IRODS_BLD_DIR}" ]; then
+	mkdir "${IRODS_BLD_DIR}"
+fi
+
+if [ ! -d "${IRODS_BUILD_PREFIX}" ]; then
+	mkdir "${IRODS_BUILD_PREFIX}"
+fi
+
+
+## Build iRODS
+
+cd "${IRODS_BLD_DIR}"
+
+"${CMAKE}" \
+	-DCMAKE_BUILD_TYPE="${IRODS_BUILD_CONFIGURATION}" \
+	-DCMAKE_INSTALL_PREFIX="${IRODS_BUILD_PREFIX}" \
+	-DCMAKE_MODULE_LINKER_FLAGS="-Wl,--enable-new-dtags -Wl,--as-needed -Wl,-z,defs -Wl,-z,origin" \
+	-DCMAKE_SHARED_LINKER_FLAGS="-Wl,--enable-new-dtags -Wl,--as-needed -Wl,-z,defs -Wl,-z,origin" \
+	"${IRODS_SRC_DIR}"
+
+make install -j"${QTY_JOBS}"
+
+
+## Build and package iCommands
+
+cd "${ICOMMANDS_BLD_DIR}"
+
+"${CMAKE}" \
+	-DCMAKE_BUILD_TYPE="${IRODS_BUILD_CONFIGURATION}" \
+	-DCMAKE_INSTALL_PREFIX="${IRODS_BUILD_PREFIX}" \
+	-DIRODS_DIR="${IRODS_BUILD_PREFIX}/lib/irods/cmake" \
+	"${ICOMMANDS_SRC_DIR}"
+
+make -j"${QTY_JOBS}" userspace-tarball

--- a/packaging/userspace/chrpath.cmake
+++ b/packaging/userspace/chrpath.cmake
@@ -1,0 +1,45 @@
+#[======================================================================[.rst:
+chrpath
+-------
+
+
+#]======================================================================]
+
+
+include_guard(GLOBAL)
+
+cmake_policy(PUSH)
+cmake_policy(SET CMP0054 NEW)
+
+macro(chrpath)
+	cmake_parse_arguments(CHRPATH "" "RPATH" "TARGETS" ${ARGN})
+
+	foreach(CHRPATH_OP_TARGET ${CHRPATH_OP_TARGETS})
+		file(READ_ELF "${CHRPATH_OP_TARGET}" RUNPATH _old_runpath_in)
+		file(READ_ELF "${CHRPATH_OP_TARGET}" RPATH _old_rpath_in)
+
+		if(_old_runpath_in)
+			set(old_rpath_in "${_old_runpath_in}")
+		else()
+			set(old_rpath_in "${_old_rpath_in}")
+		endif()
+
+		string(REPLACE ";" ":" old_rpath "${old_rpath_in}")
+
+		file(RPATH_CHANGE
+			FILE "${CHRPATH_OP_TARGET}"
+			OLD_RPATH "${old_rpath}"
+			NEW_RPATH "${CHRPATH_OP_RPATH}")
+
+		unset(old_rpath)
+		unset(old_rpath_in)
+		unset(_old_rpath_in)
+		unset(_old_runpath_in)
+	endforeach()
+endmacro()
+
+if(CMAKE_CURRENT_LIST_FILE STREQUAL CMAKE_SCRIPT_MODE_FILE)
+	chrpath(TARGETS "${CHRPATH_TARGETS}" RPATH "${NEW_CHRPATH}")
+endif()
+
+cmake_policy(POP)

--- a/packaging/userspace/compat_shims.py
+++ b/packaging/userspace/compat_shims.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Compatibility shims for some python stdlib stuff."""
+
+from __future__ import print_function
+import sys, errno  # noqa: I201; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import platform  # noqa: I100,I202
+import site
+from threading import Lock
+
+import pkg_resources
+
+site_import_paths = list(site.getsitepackages())
+if site.ENABLE_USER_SITE:
+	site_import_paths.insert(0, site.getusersitepackages())
+
+Version = type(pkg_resources.Distribution(version='0.0.0').parsed_version)
+
+_str_ver_cache = {}
+_str_ver_cache_lock = Lock()
+_inf_ver_cache = {}
+_inf_ver_cache_lock = Lock()
+
+
+def parse_version(ver_str: str) -> Version:
+	if ver_str in _str_ver_cache:
+		return _str_ver_cache[ver_str]
+	with _str_ver_cache_lock:
+		# check one more time in case it was added while waiting on the lock
+		if ver_str in _str_ver_cache:
+			return _str_ver_cache[ver_str]
+		ver = Version(ver_str)
+		_str_ver_cache[ver_str] = ver
+		return ver
+
+
+def version_info_to_version(
+	major: int = 0,
+	minor: int = 0,
+	micro: int = 0,
+	releaselevel: str = 'final',
+	serial: int = 0
+) -> Version:
+	version_info = (major, minor, micro, releaselevel, serial)
+	if version_info in _inf_ver_cache:
+		return _inf_ver_cache[version_info]
+	with _inf_ver_cache_lock:
+		# check one more time in case it was added while waiting on the lock
+		if version_info in _inf_ver_cache:
+			return _inf_ver_cache[version_info]
+		if releaselevel == 'final':
+			pre_fmt = ''
+		elif releaselevel == 'alpha':
+			pre_fmt = 'a{3}'
+		elif releaselevel == 'beta':
+			pre_fmt = 'b{3}'
+		elif releaselevel == 'candidate':
+			pre_fmt = 'rc{3}'
+		else:
+			raise ValueError('unrecognized releaselevel value')
+		ver_fmt = '{0}.{1}.{2}' + pre_fmt
+		ver_str = ver_fmt.format(major, minor, micro, serial)
+		ver = parse_version(ver_str)
+		_inf_ver_cache[version_info] = ver
+		return ver
+
+
+try:
+	python_version = version_info_to_version(
+		sys.version_info.major,
+		sys.version_info.minor,
+		sys.version_info.micro,
+		sys.version_info.releaselevel,
+		sys.version_info.serial
+	)
+except Exception:  # noqa: B902,S110; pylint: disable=W0703; nosec
+	python_version = parse_version(platform.python_version())
+
+# pylint: disable=C0412
+import collections  # noqa: I100,I202
+import typing
+from contextlib import suppress as suppress_ex
+
+if sys.version_info < (3, 9):
+	from typing import ByteString, Callable, Collection, Container, Generator, Iterable
+	from typing import Iterator, MutableSequence, MutableSet, Reversible, Sequence
+	from typing import ItemsView, KeysView, Mapping, MappingView, MutableMapping, ValuesView
+else:
+	from collections.abc import ByteString, Callable, Collection, Container, Generator, Iterable
+	from collections.abc import Iterator, MutableSequence, MutableSet, Reversible, Sequence
+	from collections.abc import ItemsView, KeysView, Mapping, MappingView, MutableMapping, ValuesView
+
+# Utility stuff
+if sys.version_info < (3, 7):
+	try:
+		from typing import _generic_new
+	except ImportError:
+		from typing import _gorg
+		def _generic_new(base_cls, cls, *args, **kwds):  # noqa: ANN001,ANN002,ANN003,ANN202
+			if cls.__origin__ is None:
+				return base_cls.__new__(cls)
+			else:
+				origin = _gorg(cls)
+				obj = base_cls.__new__(origin)
+				with suppress_ex(AttributeError):
+					obj.__orig_class__ = cls
+				obj.__init__(*args, **kwds)
+				return obj
+	try:
+		from typing import _geqv
+	except ImportError:
+		def _geqv(cls1, cls2):  # noqa: ANN001,ANN202
+			return cls1._gorg is cls2  # pylint: disable=W0212
+if (3, 7) <= sys.version_info < (3, 9):
+	from typing import _alias
+if sys.version_info < (3, 9):
+	from typing import KT, T, VT
+
+# NoReturn introduced in 3.6.2
+try:
+	from typing import NoReturn
+except ImportError:
+	NoReturn = type(None)
+
+# ChainMap and Counter were introduced in 3.6.1 and deprecated in 3.9.
+if sys.version_info < (3, 9):
+	try:
+		from typing import ChainMap
+	except ImportError:
+		class ChainMap(collections.ChainMap, MutableMapping[KT, VT], extra=collections.ChainMap):
+			__slots__ = ()
+			def __new__(cls, *args, **kwargs):  # noqa: ANN002,ANN003,ANN204
+				if _geqv(cls, ChainMap):
+					return collections.ChainMap(*args, **kwargs)
+				return _generic_new(collections.ChainMap, cls, *args, **kwargs)
+	try:
+		from typing import Counter
+	except ImportError:
+		class Counter(collections.Counter, typing.Dict[T, int], extra=collections.Counter):  # pylint: disable=W0223
+			__slots__ = ()
+			def __new__(cls, *args, **kwargs):  # noqa: ANN002,ANN003,ANN204
+				if _geqv(cls, Counter):
+					return collections.Counter(*args, **kwargs)
+				return _generic_new(collections.Counter, cls, *args, **kwargs)
+else:
+	from collections import ChainMap, Counter
+
+# OrderedDict was introduced in 3.7.2 and deprecated in 3.9
+if sys.version_info < (3, 7):
+	class OrderedDict(collections.OrderedDict, MutableMapping[KT, VT], extra=collections.OrderedDict):
+		__slots__ = ()
+		def __new__(cls, *args, **kwargs):  # noqa: ANN002,ANN003,ANN204
+			if _geqv(cls, OrderedDict):
+				return collections.OrderedDict(*args, **kwargs)
+			return _generic_new(collections.OrderedDict, cls, *args, **kwargs)
+elif sys.version_info < (3, 7, 2):
+	# For whatever reason, pylint can crash if we access collections.OrderedDict directly here
+	from collections import OrderedDict as OrderedDict_collections
+	OrderedDict = _alias(OrderedDict_collections, (KT, VT))
+elif sys.version_info < (3, 9):
+	# Whatever Wing uses to underline problematic code thinks typing.OrderedDict doesn't exist
+	OrderedDict = typing.OrderedDict  # noqa: TYP006
+else:
+	OrderedDict = collections.OrderedDict
+
+# Protocol was introduced in 3.8.
+# _Protocol is an internal type we can use as a shim for < 3.8
+if sys.version_info < (3, 8):
+	from typing import _Protocol as Protocol  # pylint: disable=E0611
+else:
+	from typing import Protocol
+
+# AbstractSet -> Set
+# defaultdict -> DefaultDict
+# tuple -> Tuple
+# type -> Type
+if sys.version_info < (3, 9):
+	from typing import AbstractSet as Set
+	from typing import DefaultDict
+	from typing import Tuple
+	from typing import Type
+else:
+	from collections.abc import Set
+	from collections import defaultdict as DefaultDict
+	Tuple = tuple
+	Type = type
+
+# platform.linux_distribution was deprecated in 3.5 and removed in 3.8
+# the distro package is the recommended replacement
+try:
+	from distro import linux_distribution
+except ImportError:
+	if sys.version_info < (3, 8):
+		from platform import linux_distribution
+	else:
+		raise
+
+__all__ = [
+	'Version',
+	'parse_version',
+	'version_info_to_version',
+	'python_version',
+	'ByteString',
+	'Callable',
+	'Collection',
+	'Container',
+	'Generator',
+	'Iterable',
+	'Iterator',
+	'MutableSequence',
+	'MutableSet',
+	'Sequence',
+	'ItemsView',
+	'KeysView',
+	'Mapping',
+	'MappingView',
+	'MutableMapping',
+	'ValuesView',
+	'NoReturn',
+	'Reversible',
+	'OrderedDict',
+	'Protocol',
+	'Set',
+	'DefaultDict',
+	'Tuple',
+	'Type',
+	'linux_distribution'
+]

--- a/packaging/userspace/context.py
+++ b/packaging/userspace/context.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import os  # noqa: I100,I202
+import logging  # noqa: I100
+import tempfile
+from contextlib import suppress as suppress_ex
+from os import path
+from typing import Any, Generic, Optional, TypeVar
+
+import script_common
+import log_instrumentation as logging_ext
+from compat_shims import MutableMapping, MutableSequence, NoReturn
+from lief_instrumentation import LiefModuleT, lief_ver_info
+from options import DecrementAction, IncrementAction
+from options import RunArgGroup, RunArgOption, RunOption, RunOptsContainer, RunWhininessArg
+
+__all__ = ['PackagerOptionsBase', 'OptionsT', 'PackagerContext', 'augment_module_search_paths']
+
+
+class PackagerOptionsBase(RunOptsContainer):  # pylint: disable=W0223
+	ipath_args = RunArgGroup('iRODS paths')
+
+	irods_install_prefix: str = RunArgOption(
+		'--irods-install-prefix', metavar='PATH',
+		group=ipath_args,
+		action='store', opt_type=str, default='/usr'
+	)
+	irods_package_prefix: str = RunArgOption(
+		'--irods-package-prefix', metavar='PATH',
+		group=ipath_args,
+		action='store', opt_type=str, default='/usr'
+	)
+	irods_home_dir: str = RunArgOption(
+		'--irods-home-dir', metavar='PATH',
+		group=ipath_args,
+		action='store', opt_type=str, default='/var/lib/irods',
+		help='iRODS home directory'
+	)
+	irods_scripts_dir: Optional[str] = RunArgOption(
+		'--irods-scripts-dir', metavar='PATH',
+		group=ipath_args,
+		action='store', opt_type=str, default=None,
+		help='iRODS scripts directory'
+	)
+
+	LD_LIBRARY_PATH: MutableSequence[str] = RunArgOption(
+		'--ld_library_path', metavar='PATH',
+		action='append', opt_type=str, default=[],
+		help='Directory to prepend to LD_LIBRARY_PATH'
+	)
+
+	sharedlib_suffixes: MutableSequence[str] = RunArgOption(
+		'--sharedlib-suffix', metavar='EXT',
+		action='append', opt_type=str, default=['.so']
+	)
+
+	cmake_tmpdir: str = RunArgOption(
+		'--cmake-tmpdir', metavar='PATH',
+		action='store', opt_type=str, default=tempfile.gettempdir()
+	)
+
+	gnuinstalldirs_args = RunArgGroup('GNUInstallDirs')
+
+	tool_args = RunArgGroup('Tool paths')
+
+	verbosity_args = RunArgGroup('Output verbosity')
+	verbosity: int = RunOption(opt_type=int, default=0)
+
+	_quiet_arg = RunWhininessArg(
+		'-q', '--quiet',
+		group=verbosity_args,
+		action=DecrementAction, dest=verbosity,
+		help='Decrease verbosity'
+	)
+	_verbose_arg = RunWhininessArg(
+		'-v', '--verbose',
+		group=verbosity_args,
+		action=IncrementAction, dest=verbosity,
+		help='Increase verbosity'
+	)
+
+
+OptionsT = TypeVar('OptionsT', bound=PackagerOptionsBase)
+
+
+class PackagerContext(Generic[OptionsT]):
+	_packager_dir = path.dirname(path.abspath(path.realpath(__file__)))
+
+	#@classmethod
+	@property
+	def packager_dir(cls) -> str:
+		return cls._packager_dir
+
+	def __new__(cls, options: Optional[OptionsT]):  # noqa: ANN204; pylint: disable=W0613
+		obj = super().__new__(cls)
+
+		if not hasattr(cls, '_lief'):
+			cls._lief = None
+			cls._lief_info = None
+			try:
+				import lief
+			except ImportError:
+				cls._lief_info = lief_ver_info(None)
+			else:
+				cls._lief = lief
+				cls._lief_info = lief_ver_info(lief)
+
+		if not hasattr(cls, 'ilib'):
+			try:
+				from irods import execute as _ilib
+			except ImportError:
+				from irods import lib as _ilib
+			cls.ilib = _ilib
+
+		return obj
+
+	def __init__(self, options: Optional[OptionsT] = None):
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		l.debug('PackagerContext: __init__ called')
+
+		self._options = options
+
+		self._envdict = {}
+		if options and options.LD_LIBRARY_PATH:
+			ld_libpath = ':'.join(options.LD_LIBRARY_PATH)
+			if 'LD_LIBRARY_PATH' in os.environ:
+				self._envdict['LD_LIBRARY_PATH'] = ld_libpath + os.environ['LD_LIBRARY_PATH']
+			else:
+				self._envdict['LD_LIBRARY_PATH'] = ld_libpath
+
+	#@classmethod
+	@property
+	def lief(cls) -> Optional[LiefModuleT]:
+		return cls._lief
+
+	#@classmethod
+	@property
+	def lief_info(cls) -> lief_ver_info:
+		return cls._lief_info
+
+	@property
+	def options(self) -> Optional[OptionsT]:
+		return self._options
+
+	@property
+	def envdict(self) -> MutableMapping[str, str]:
+		return self._envdict
+
+	_logging_initialized = False
+
+	#@classmethod
+	@property
+	def logging_initialized(cls) -> bool:
+		return cls._logging_initialized
+
+	@classmethod
+	def _set_logging_initialized(cls, value: bool) -> NoReturn:
+		cls._logging_initialized = value
+
+	def init_logging(self, verbosity: int) -> NoReturn:
+		# we don't want redundant output, so make sure we don't initialize more than once
+		if self.logging_initialized:
+			return
+
+		logging_ext.init_logging(verbosity)
+		self.lief_info.init_logging(verbosity)
+
+		self._set_logging_initialized(True)
+
+	def trace(  # pylint: disable=R0201
+		self,
+		logger: logging.Logger,
+		msg: str,
+		*args: Any,
+		**kwargs: Any
+	) -> NoReturn:
+		logging_ext.trace(logger, msg, *args, **kwargs)
+
+	def message(  # pylint: disable=R0201
+		self,
+		logger: logging.Logger,
+		msg: str,
+		*args: Any,
+		**kwargs: Any
+	) -> NoReturn:
+		logging_ext.message(logger, msg, *args, **kwargs)
+
+	def status(  # pylint: disable=R0201
+		self,
+		logger: logging.Logger,
+		msg: str,
+		*args: Any,
+		**kwargs: Any
+	) -> NoReturn:
+		logging_ext.status(logger, msg, *args, **kwargs)
+
+
+def augment_module_search_paths(options: Optional[PackagerOptionsBase] = None) -> NoReturn:
+	if not options:
+		pass
+	elif options.irods_scripts_dir:
+		script_common.irods_scripts_dir = options.irods_scripts_dir
+	elif options.irods_package_prefix:
+		if path.isabs(options.irods_home_dir):
+			script_common.irods_scripts_dir = path.join(
+				options.irods_package_prefix,
+				options.irods_home_dir[1:],
+				'scripts'
+			)
+		else:
+			script_common.irods_scripts_dir = path.join(
+				options.irods_package_prefix,
+				options.irods_home_dir,
+				'scripts'
+			)
+	else:
+		script_common.irods_scripts_dir = path.join(
+			options.irods_install_prefix,
+			options.irods_home_dir,
+			'scripts'
+		)
+
+	if not path.isabs(script_common.irods_scripts_dir):
+		raise OSError(
+			errno.EINVAL,
+			'irods_scripts_dir is not an absolute path',
+			script_common.irods_scripts_dir
+		)
+	if not path.exists(script_common.irods_scripts_dir):
+		raise OSError(
+			errno.ENOENT,
+			'irods_scripts_dir not found',
+			script_common.irods_scripts_dir
+		)
+	if not path.isdir(script_common.irods_scripts_dir):
+		raise OSError(
+			errno.ENOTDIR,
+			'irods_scripts_dir is not a directory',
+			script_common.irods_scripts_dir
+		)
+
+	# If the irods script dir is already in the search paths, do nothing
+	for searchpath in sys.path:
+		with suppress_ex(OSError):
+			if path.samefile(searchpath, script_common.irods_scripts_dir):
+				return
+
+	sys.path.insert(1, script_common.irods_scripts_dir)

--- a/packaging/userspace/elfinfo_util.py
+++ b/packaging/userspace/elfinfo_util.py
@@ -1,0 +1,937 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import logging  # noqa: I100,I202
+import re
+from concurrent.futures import Executor
+from enum import Enum
+from os import path
+from threading import Lock
+from typing import Any, Generic, Optional, TypeVar, Union, overload
+
+from compat_shims import Iterable, Iterator, MutableSequence, MutableSet, NoReturn, OrderedDict
+from compat_shims import Reversible, Sequence, Tuple
+from compat_shims import ItemsView, KeysView, Mapping, MutableMapping, ValuesView
+from context import PackagerContext, PackagerOptionsBase
+from script_common import FrozenList
+from options import RunArgOption
+from utilbase import PackagerOperationToolState, PackagerToolState, PackagerUtilBase, ToolStateT
+
+__all__ = [
+	'ElfInfoUtil',
+	'ElfInfo',
+	'ElfVersionRefGroup',
+	'ElfInfoUtilOptionsBase',
+	'TableValueT',
+	'LddLibPaths',
+	'ElfInfoSource',
+	'DynamicSectionTableBase',
+	'DynamicSectionKeysView',
+	'DynamicSectionValuesView',
+	'DynamicSectionIndivValuesView',
+	'DynamicSectionItemsView',
+	'DynamicSectionIndivItemsView',
+	'DynamicSectionTable',
+	'ElfInfoToolStateBase',
+	'ElfInfoToolState',
+	'ElfInfoOperationState'
+]
+
+
+class ElfInfoUtilOptionsBase(PackagerOptionsBase):  # pylint: disable=W0223
+	ldd_path: Optional[str] = RunArgOption(
+		'--ldd-path', metavar='TOOLPATH',
+		group=PackagerOptionsBase.tool_args,
+		action='store', opt_type=str, default=None,
+		help='Path to ldd tool to use'
+	)
+	readelf_path: Optional[str] = RunArgOption(
+		'--readelf-path', metavar='TOOLPATH',
+		group=PackagerOptionsBase.tool_args,
+		action='store', opt_type=str, default=None,
+		help='Path to readelf tool to use'
+	)
+	objdump_path: Optional[str] = RunArgOption(
+		'--objdump-path', metavar='TOOLPATH',
+		group=PackagerOptionsBase.tool_args,
+		action='store', opt_type=str, default=None,
+		help='Path to objdump tool to use'
+	)
+
+
+class ElfInfoToolStateBase(Generic[ToolStateT]):
+
+	def __init__(
+		self,
+		ldd_tool: ToolStateT,
+		lief_tool: ToolStateT,
+		readelf_tool: ToolStateT,
+		objdump_tool: ToolStateT
+	):
+		self._ldd_tool = ldd_tool
+		self._lief_tool = lief_tool
+		self._readelf_tool = readelf_tool
+		self._objdump_tool = objdump_tool
+
+	@property
+	def ldd_tool(self) -> ToolStateT:
+		return self._ldd_tool
+
+	@property
+	def ldd(self) -> ToolStateT:
+		return self.ldd_tool
+
+	@property
+	def lief_tool(self) -> ToolStateT:
+		return self._lief_tool
+
+	@property
+	def lief(self) -> ToolStateT:
+		return self.lief_tool
+
+	@property
+	def readelf_tool(self) -> ToolStateT:
+		return self._readelf_tool
+
+	@property
+	def readelf(self) -> ToolStateT:
+		return self.readelf_tool
+
+	@property
+	def objdump_tool(self) -> ToolStateT:
+		return self._objdump_tool
+
+	@property
+	def objdump(self) -> ToolStateT:
+		return self.objdump_tool
+
+	@property
+	def elftools_usable(self) -> bool:
+		return self.lief_tool or self.readelf_tool #or self.objdump_tool
+
+
+class ElfInfoToolState(ElfInfoToolStateBase[PackagerToolState]):
+	pass
+
+
+class ElfInfoOperationState(ElfInfoToolStateBase[PackagerOperationToolState]):
+
+	def __init__(self, tool_state: ElfInfoToolState):
+		ldd_tool = PackagerOperationToolState(tool_state.ldd_tool)
+		lief_tool = PackagerOperationToolState(tool_state.lief_tool)
+		readelf_tool = PackagerOperationToolState(tool_state.readelf_tool)
+		objdump_tool = PackagerOperationToolState(tool_state.objdump_tool)
+		super().__init__(ldd_tool, lief_tool, readelf_tool, objdump_tool)
+
+
+class LddLibPaths():
+
+	def __init__(
+		self,
+		lib_paths: MutableMapping[str, str],
+		not_found: MutableSet[str],
+		other_libs: MutableSet[str]
+	):
+		super().__init__()
+		self._lib_paths = lib_paths
+		self._not_found = not_found
+		self._other_libs = other_libs
+		self._repr_format: str = (
+			self.__class__.__name__ + '(lib_paths=%r, not_found=%r, other_libs=%r)'
+		)
+
+	@property
+	def lib_paths(self) -> MutableMapping[str, str]:
+		return self._lib_paths
+
+	@property
+	def not_found(self) -> MutableSet[str]:
+		return self._not_found
+
+	@property
+	def other_libs(self) -> MutableSet[str]:
+		return self._other_libs
+
+	def __repr__(self) -> str:
+		if not self:
+			return self.__class__.__name__ + '()'
+		return self._repr_format % (self.lib_paths, self.not_found, self.other_libs)
+
+
+class ElfInfoSource(Enum):
+	READELF = 1
+	OBJDUMP = 2
+	LIEF = 3
+
+
+TableValueT = TypeVar('TableValueT')
+
+
+class DynamicSectionTableBase(Generic[TableValueT]):
+
+	def __init__(self, table: OrderedDict[str, MutableSequence[Any]]):
+		self._table: OrderedDict[str, MutableSequence[TableValueT]] = table
+
+	def _len_group(self) -> int:
+		sz = 0
+		for seq in self._table.values():
+			if len(seq) > 0:
+				sz += 1
+		return sz
+
+	def _len_indiv(self) -> int:
+		sz = 0
+		for seq in self._table.values():
+			sz += len(seq)
+		return sz
+
+
+class DynamicSectionKeysView(DynamicSectionTableBase[TableValueT], KeysView[str], Reversible[str]):
+
+	def __init__(self, table: OrderedDict[str, MutableSequence[TableValueT]]):
+		KeysView.__init__(self, table)  # pylint: disable=W0233
+		DynamicSectionTableBase.__init__(self, table)  # pylint: disable=W0233
+
+	def __contains__(self, key: str) -> bool:
+		try:
+			return len(self._mapping[key]) > 0
+		except KeyError:
+			return False
+
+	def __len__(self) -> int:
+		return self._len_group()
+
+	def _iter(  # pylint: disable=R0201
+		self,
+		iterator: Iterator[Tuple[str, Sequence[TableValueT]]]
+	) -> Iterator[str]:
+		for tag, seq in iterator:
+			if len(seq) > 0:
+				yield tag
+
+	def __iter__(self) -> Iterator[str]:
+		return self._iter(self._table.items())
+
+	def __reversed__(self) -> Iterator[str]:
+		return self._iter(reversed(self._table.items()))
+
+
+class DynamicSectionItemsView(
+	DynamicSectionTableBase[TableValueT],
+	ItemsView[str, MutableSequence[TableValueT]],
+	Reversible[Tuple[str, MutableSequence[TableValueT]]]
+):
+
+	def __init__(self, table: OrderedDict[str, MutableSequence[TableValueT]]):
+		ItemsView.__init__(self, table)  # pylint: disable=W0233
+		DynamicSectionTableBase.__init__(self, table)  # pylint: disable=W0233
+
+	def __contains__(self, item: Tuple[str, Sequence[TableValueT]]) -> bool:
+		tag, iseq = item
+		if iseq is None or len(iseq) < 1:
+			return False
+		try:
+			tseq = self._table[tag]
+		except KeyError:
+			return False
+		else:
+			if tseq is None or len(tseq) < 1:
+				return False
+			return tseq is iseq or tseq == iseq
+
+	def __len__(self) -> int:
+		return self._len_group()
+
+	def _iter(  # pylint: disable=R0201
+		self,
+		iterator: Iterator[Tuple[str, MutableSequence[TableValueT]]]
+	) -> Iterator[Tuple[str, MutableSequence[TableValueT]]]:
+		for tag, seq in iterator:
+			if len(seq) > 0:
+				yield (tag, seq)
+
+	def __iter__(self) -> Iterator[Tuple[str, MutableSequence[TableValueT]]]:
+		return self._iter(self._table.items())
+
+	def __reversed__(self) -> Iterator[Tuple[str, MutableSequence[TableValueT]]]:
+		return self._iter(reversed(self._table.items()))
+
+
+class DynamicSectionIndivItemsView(
+	DynamicSectionTableBase[TableValueT],
+	ItemsView[str, TableValueT],
+	Reversible[Tuple[str, TableValueT]]
+):
+
+	def __init__(self, table: OrderedDict[str, Sequence[TableValueT]]):
+		ItemsView.__init__(self, table)  # pylint: disable=W0233
+		DynamicSectionTableBase.__init__(self, table)  # pylint: disable=W0233
+
+	def __contains__(self, item: Tuple[str, TableValueT]) -> bool:
+		tag, ival = item
+		try:
+			seq = self._table[tag]
+		except KeyError:
+			return False
+		else:
+			return any(sval is ival or sval == ival for sval in seq)
+
+	def __len__(self) -> int:
+		return self._len_indiv()
+
+	def __iter__(self) -> Iterator[Tuple[str, TableValueT]]:
+		for tag, seq in self._table.items():
+			for value in seq:
+				yield (tag, value)
+
+	def __reversed__(self) -> Iterator[Tuple[str, TableValueT]]:
+		for tag, seq in reversed(self._table.items()):
+			for value in reversed(seq):
+				yield (tag, value)
+
+
+class DynamicSectionValuesView(
+	DynamicSectionTableBase[TableValueT],
+	ValuesView[MutableSequence[TableValueT]],
+	Reversible[MutableSequence[TableValueT]]
+):
+
+	def __init__(self, table: OrderedDict[str, MutableSequence[TableValueT]]):
+		ValuesView.__init__(self, table)  # pylint: disable=W0233
+		DynamicSectionTableBase.__init__(self, table)  # pylint: disable=W0233
+
+	def __contains__(self, value: Sequence[TableValueT]) -> bool:
+		if value is None or len(value) < 1:
+			return False
+		return any(seq is value or seq == value for seq in self._table.values())
+
+	def __len__(self) -> int:
+		return self._len_group()
+
+	def _iter(  # pylint: disable=R0201
+		self,
+		iterator: Iterator[MutableSequence[TableValueT]]
+	) -> Iterator[MutableSequence[TableValueT]]:
+		for seq in iterator:
+			if len(seq) > 0:
+				yield seq
+
+	def __iter__(self) -> Iterator[MutableSequence[TableValueT]]:
+		return self._iter(self._table.values())
+
+	def __reversed__(self) -> Iterator[MutableSequence[TableValueT]]:
+		return self._iter(reversed(self._table.values()))
+
+
+class DynamicSectionIndivValuesView(
+	DynamicSectionTableBase[TableValueT],
+	ValuesView[TableValueT],
+	Reversible[TableValueT]
+):
+
+	def __init__(self, table: OrderedDict[str, Sequence[TableValueT]]):
+		ValuesView.__init__(self, table)  # pylint: disable=W0233
+		DynamicSectionTableBase.__init__(self, table)  # pylint: disable=W0233
+
+	def __contains__(self, value: TableValueT) -> bool:
+		return any(value in seq for seq in self._table.values())
+
+	def __len__(self) -> int:
+		return self._len_indiv()
+
+	def __iter__(self) -> Iterator[Tuple[str, TableValueT]]:
+		for seq in self._table.values():
+			yield from seq
+
+	def __reversed__(self) -> Iterator[Tuple[str, TableValueT]]:
+		for seq in reversed(self._table.values()):
+			yield from reversed(seq)
+
+
+# TODO: This could serve as the basis for a generic multi-value map class
+class DynamicSectionTable(
+	DynamicSectionTableBase[TableValueT],
+	MutableMapping[str, MutableSequence[TableValueT]],
+	Reversible[str]
+):
+
+	@overload
+	def __init__(
+		self,
+		source: Optional[ElfInfoSource] = None
+	):
+		pass
+
+	@overload
+	def __init__(
+		self,
+		mapping: Mapping[str, Iterable[TableValueT]],
+		source: Optional[ElfInfoSource] = None
+	):
+		pass
+
+	@overload
+	def __init__(
+		self,
+		iterable: Iterable[Tuple[str, Iterable[TableValueT]]],
+		source: Optional[ElfInfoSource] = None
+	):
+		pass
+
+	def __init__(
+		self,
+		*args,
+		source: Optional[ElfInfoSource] = None
+	):
+		if len(args) > 1:
+			raise ValueError('Too many positional arguments')
+
+		MutableMapping.__init__(self)  # pylint: disable=W0233
+		DynamicSectionTableBase.__init__(self, OrderedDict(*args))  # pylint: disable=W0233
+
+		self._source = source
+		self._lock: Lock = Lock()
+
+	@property
+	def source(self) -> ElfInfoSource:
+		return self._source
+
+	def setdefault(
+		self,
+		key: str,
+		default: Optional[Sequence[TableValueT]] = None
+	) -> MutableSequence[TableValueT]:
+		if not isinstance(key, str):
+			raise TypeError('key must be string')
+		with self._lock:
+			if key in self._table:
+				seq = self._table[key]
+				if len(seq) < 0:
+					return seq
+				else:
+					if default is not None:
+						seq = list(default)
+						self._table[key] = seq
+					self._table.move_to_end(key)
+					return seq
+			if default:
+				seq = list(default)
+			else:
+				seq = []
+			self._table[key] = seq
+			self._table.move_to_end(key)
+			return seq
+
+	def __getitem__(self, key: str) -> MutableSequence[TableValueT]:
+		return self.setdefault(key)
+
+	def __len__(self) -> int:
+		return self._len_indiv()
+
+	def __contains__(self, key: str) -> bool:
+		try:
+			return len(self._table[key]) > 0
+		except KeyError:
+			return False
+
+	def __iter__(self) -> Iterator[str]:
+		return iter(self.keys())
+
+	def __reversed__(self) -> Iterator[str]:
+		return iter(reversed(self.keys()))
+
+	def __setitem__(self, key: str, value: MutableSequence[TableValueT]) -> NoReturn:
+		with self._lock:
+			if value is None and value in self._table:
+				del self._table
+			else:
+				self._table[key] = value
+				if len(value) < 1:
+					self._table.move_to_end(key)
+
+	def __delitem__(self, key: str) -> NoReturn:
+		try:
+			del self._table[key]
+		except (KeyError, IndexError):
+			if not isinstance(key, str):
+				raise TypeError('key must be string')  # pylint: disable=W0707
+
+	# NOTE: while __getitem__() will create entries in the underlying map, get() is a read-only
+	# operation. If default is returned, updating the returned sequence will not update the data in
+	# the table.
+	# see also: setdefault
+	def get(
+		self,
+		key: str,
+		default: Optional[Sequence[TableValueT]] = None
+	) -> Optional[Union[MutableSequence[TableValueT], Sequence[TableValueT]]]:
+		with self._lock:
+			if key in self._table:
+				seq = self._table[key]
+				if len(seq) > 0:
+					return seq
+			return default
+
+	def add(self, key: str, value: TableValueT) -> NoReturn:
+		self[key].append(value)
+
+	# TODO: implement DynamicSectionTable.pop
+	def pop(self, key: str, default=None):
+		raise NotImplementedError
+
+	# TODO: implement DynamicSectionTable.popitem
+	def popitem(self, last: bool = True) -> Tuple[str, TableValueT]:  # noqa: W0221
+		raise NotImplementedError
+
+	def popentry(
+		self,
+		key: str,
+		last: bool = True,
+		default: Optional[TableValueT] = None
+	) -> Optional[TableValueT]:
+		with self._lock:
+			if key in self._table:
+				seq = self._table[key]
+				if len(seq) < 1:
+					self._table.move_to_end(key)
+					return default
+				popidx = -1 if last else 0
+				return seq.pop(index=popidx)
+			return default
+
+	def popgroup(
+		self,
+		key: str,
+		default: Sequence[TableValueT] = None
+	) -> Union[MutableSequence[TableValueT], Sequence[TableValueT]]:
+		with self._lock:
+			if key in self._table:
+				seq = self._table[key]
+				if len(seq) < 1:
+					if default:
+						seq = default
+					else:
+						seq = []
+				del self._table[key]
+				return seq
+			if default:
+				return default
+			return []
+
+	def clear(self) -> NoReturn:
+		with self._lock:
+			for seq in self._table.values():
+				seq.clear()
+
+	# TODO: implement DynamicSectionTable.update
+	def update(self, *args, **kwargs):
+		raise NotImplementedError
+
+	def keys(self) -> DynamicSectionKeysView:
+		return DynamicSectionKeysView(self._table)
+
+	def items(self) -> DynamicSectionIndivItemsView[TableValueT]:
+		return DynamicSectionIndivItemsView[TableValueT](self._table)
+
+	def values(self) -> DynamicSectionIndivValuesView[TableValueT]:
+		return DynamicSectionIndivValuesView[TableValueT](self._table)
+
+	def itemgroups(self) -> DynamicSectionItemsView[TableValueT]:
+		return DynamicSectionItemsView[TableValueT](self._table)
+
+	def valuegroups(self) -> DynamicSectionValuesView[TableValueT]:
+		return DynamicSectionValuesView[TableValueT](self._table)
+
+
+class ElfVersionRefGroup(FrozenList[str]):
+
+	@overload
+	def __init__(self, soname: str):
+		pass
+
+	@overload
+	def __init__(self, soname: str, entries: Iterable[str]):
+		pass
+
+	def __init__(self, soname: str, *args: Iterable[str]):
+		if len(args) > 1:
+			raise ValueError('Too many positional arguments')
+		elif len(args) == 1 and args[0] is not None:
+			super().__init__(args[0])
+		else:
+			super().__init__()
+
+		self._soname = soname
+
+	@property
+	def soname(self) -> str:
+		return self._soname
+
+
+class ElfInfo():
+
+	def __init__(
+		self,
+		*,
+		source: Optional[ElfInfoSource] = None,
+		rpath: Optional[Sequence[str]] = None,
+		runpath: Optional[Sequence[str]] = None,
+		imported_libs: Optional[Sequence[str]] = None,
+		has_origin_flag: bool = False,
+		has_origin_flag_1: bool = False,
+		version_refs: Optional[Sequence[ElfVersionRefGroup]] = None
+	):
+		self._source = source
+		self._rpath = None if rpath is None else FrozenList(rpath)
+		self._runpath = None if runpath is None else FrozenList(runpath)
+		self._imported_libs = FrozenList(imported_libs) if imported_libs else FrozenList()
+		self._has_origin_flag = has_origin_flag
+		self._has_origin_flag_1 = has_origin_flag_1
+		self._version_refs = FrozenList(version_refs) if version_refs else FrozenList()
+
+	@property
+	def source(self) -> Optional[ElfInfoSource]:
+		return self._source
+
+	@property
+	def rpath(self) -> Optional[Sequence[str]]:
+		return self._rpath
+
+	@property
+	def runpath(self) -> Optional[Sequence[str]]:
+		return self._runpath
+
+	@property
+	def imported_libs(self) -> Sequence[str]:
+		return self._imported_libs
+
+	@property
+	def has_origin_flag(self) -> bool:
+		return self._has_origin_flag
+
+	@property
+	def has_origin_flag_1(self) -> bool:
+		return self._has_origin_flag_1
+
+	@property
+	def version_refs(self) -> Sequence[ElfVersionRefGroup]:
+		return self._version_refs
+
+
+# TODO: Implement fetching DT_NEEDED entries using objdump.
+# TODO: Implement fetching DF_ORIGIN status using objdump.
+# TODO: Implement fetching rpath and runpath using readelf and objdump.
+# TODO: (maybe?) Implement fetching of symbol versioning info using readelf and objdump.
+# A lot of the regex for all three is already done at the bottom of this class.
+# TODO: Concurrency, baby!
+# TODO: Identify earliest version of llvm-objdump to support display of dynamic section
+# TODO: Identify earliest version of llvm-readelf to support GNU output for -V
+# TODO: Use elf info to make strip util and runpath util smarter
+class ElfInfoUtil(PackagerUtilBase[ElfInfoUtilOptionsBase]):
+
+	# readelf and objdump are not used currently, but in the future, we may need to support
+	# getting the soname from a library, and these would come in handy.
+	def __init__(
+		self,
+		context: PackagerContext[ElfInfoUtilOptionsBase],
+		executor: Optional[Executor] = None,
+		raise_if_ldd_not_found: bool = False,
+		raise_if_elftools_not_found: bool = False
+	):
+		super().__init__(context, executor)
+
+		env = self.fill_out_envdict()
+
+		ldd_path = self.find_tool(
+			['ldd'],
+			self.options.ldd_path,
+			raise_if_not_found=raise_if_ldd_not_found,
+			env=env
+		)
+		readelf_path = self.find_tool(
+			['readelf', 'eu-readelf', 'llvm-readelf'],
+			self.options.readelf_path,
+			raise_if_not_found=False,
+			prettyname='readelf',
+			env=env
+		)
+		objdump_path = self.find_tool(
+			['objdump', 'llvm-objdump'],
+			self.options.objdump_path,
+			raise_if_not_found=False,
+			env=env
+		)
+
+		self._tool_state = ElfInfoToolState(
+			PackagerToolState(is_usable=bool(ldd_path), path=ldd_path),
+			PackagerToolState(is_usable=self.lief_info.lief_usable),
+			PackagerToolState(is_usable=bool(readelf_path), path=readelf_path),
+			PackagerToolState(is_usable=bool(objdump_path), path=objdump_path)
+		)
+
+		if raise_if_elftools_not_found and not self.tool_state.elftools_usable:
+			raise OSError(
+				errno.ENOPKG,
+				'lief functionality not available and neither readelf nor objdump could be found'
+			)
+
+	@property
+	def tool_state(self) -> ElfInfoToolState:
+		return self._tool_state
+
+	_re_ldd_unused_dep = re.compile(r'^[ \t]+(.+)$', re.MULTILINE)
+
+	def get_unused_dependencies(
+		self,
+		bin_path: str,
+		return_full_paths: bool = False
+	) -> MutableSequence[str]:
+		ilib = self.ilib
+
+		env = self.fill_out_envdict()
+		env['LANG'] = 'C'
+
+		# FIXME: this doesn't work with musl ldd
+		ldd_args = [self.tool_state.ldd.path, '-r', '-u', bin_path]
+
+		ldd_out, ldd_err, ldd_retcode = ilib.execute_command_permissive(ldd_args, env=env)
+
+		# ldd returns 1 if unneeded libraries are found
+		if ldd_retcode == 1:
+			ldd_retcode = 0
+		ilib.check_command_return(ldd_args, ldd_out, ldd_err, ldd_retcode, env=env)
+
+		unused_deps = self._re_ldd_unused_dep.findall(ldd_out)
+
+		if return_full_paths:
+			return unused_deps
+
+		return [path.basename(ulibpath) for ulibpath in unused_deps]
+
+	# if the output format of ldd/ld.so ever changes, this will probably break
+	_rp_ldd_soname = r'^[ \t]+(?P<soname>[^><\n]+)'
+	_rp_ldd_address = r'\(0x[0-9a-f]+(, 0x[0-9a-f]+)?\)$'
+	_re_ldd_lib_path = re.compile(
+		_rp_ldd_soname + r'[ \t]+=>[ \t]+(?P<path>[^><\n]*)[ \t]+' + _rp_ldd_address,
+		re.MULTILINE
+	)
+	_re_ldd_virt_result = re.compile(
+		_rp_ldd_soname + r'[ \t]+' + _rp_ldd_address,
+		re.MULTILINE
+	)
+	_re_ldd_not_found = re.compile(
+		_rp_ldd_soname + r'[ \t]+=>[ \t]+not found$' + _rp_ldd_address,
+		re.MULTILINE
+	)
+
+	def get_lib_paths(self, bin_path: str) -> LddLibPaths:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		ilib = self.ilib
+
+		env = self.fill_out_envdict()
+		env['LANG'] = 'C'
+
+		lib_paths = {}
+		not_found = set()
+		other_libs = set()
+
+		# FIXME: musl ldd behaves differently for missing libs
+		ldd_out, ldd_err = ilib.execute_command(  # pylint: disable=W0612
+			[self.tool_state.ldd.path, bin_path],
+			env=env
+		)
+
+		for ldd_out_l in ldd_out.splitlines():
+			ldd_out_l_re = self._re_ldd_lib_path.match(ldd_out_l)
+
+			if not ldd_out_l_re:
+				ldd_out_l_re = self._re_ldd_virt_result.match(ldd_out_l)
+				if not ldd_out_l_re:
+					ldd_out_l_re = self._re_ldd_not_found.match(ldd_out_l)
+					if ldd_out_l_re:
+						not_found.add(ldd_out_l_re.groupdict()['soname'])
+					continue
+
+			ldd_out_l_re_g = ldd_out_l_re.groupdict()
+			soname = ldd_out_l_re_g['soname']
+			libpath = ldd_out_l_re_g.get('path', None)
+
+			if path.isabs(soname):
+				other_libs.add(path.basename(soname))
+				continue
+			elif not libpath:
+				other_libs.add(soname)
+				continue
+			elif not path.exists(libpath):
+				l.error('path %s from ldd does not exist', libpath)
+				continue
+
+			lib_paths[soname] = libpath
+
+		return LddLibPaths(lib_paths, not_found, other_libs)
+
+	_rp_readelf_d_tag_int = r'(?P<tag_int>0x[0-9a-f]+)?(?(tag_int)[ \t]+)'
+	_rp_readelf_d_tag_name = r'(?P<tagn_lparen>\()?(?P<tag_name>[A-Z0-9_]+)(?(tagn_lparen)(?P<tagn_rparen>\)))'
+	_rp_readelf_d_value = r'[ \t]+(?P<value>[^\n]*)$'
+	_re_readelf_dynsect = re.compile(
+		r'^[ \t]+' + _rp_readelf_d_tag_int + _rp_readelf_d_tag_name + _rp_readelf_d_value,
+		re.MULTILINE
+	)
+
+	def _get_dynamic_section_readelf(self, bin_path: str) -> DynamicSectionTable[str]:
+		ilib = self.ilib
+
+		dynsect = DynamicSectionTable[str](source=ElfInfoSource.READELF)
+
+		env = self.fill_out_envdict()
+		env['LANG'] = 'C'
+
+		readelf_out, readelf_err = ilib.execute_command(  # pylint: disable=W0612
+			[self.tool_state.readelf.path, '-W', '-d', bin_path],
+			env=env
+		)
+
+		for readelf_out_l in readelf_out.splitlines():
+			readelf_out_l_re = self._re_readelf_dynsect.match(readelf_out_l)
+			if not readelf_out_l_re:
+				continue
+			readelf_out_l_re_g = readelf_out_l_re.groupdict()
+			dynsect.add(readelf_out_l_re_g['tag_name'], readelf_out_l_re_g.get('value'))
+
+		return dynsect
+
+	_re_readelf_d_sharedlib = re.compile(
+		r'^Shared library:\s+\[(?P<soname>[^><\n\]]+)\]$',
+		re.MULTILINE
+	)
+
+	def _get_elfinfo_readelf(self, bin_path: str) -> MutableSequence[str]:
+		dynsect = self._get_dynamic_section_readelf(bin_path)
+
+		# TODO: readelf rpath/runpath extraction
+		# looks like most readelf impls do 'Library runpath: []' or 'Library rpath: []'.
+		# old llvm-readelf just does the string
+
+		imported_libs = []
+		d_neededs = dynsect['NEEDED']
+		for needed in d_neededs:
+			needed_re = self._re_readelf_d_sharedlib.match(needed)
+			needed_re_g = needed_re.groupdict()
+			imported_libs.append(needed_re_g['soname'])
+
+		has_origin_flag = False
+		if 'FLAGS' in dynsect and len(dynsect['FLAGS']) > 0:
+			# Assume there is only one FLAGS entry
+			has_origin_flag = 'ORIGIN' in dynsect['FLAGS'][0]
+
+		has_origin_flag_1 = False
+		if 'FLAGS_1' in dynsect and len(dynsect['FLAGS_1']) > 0:
+			# Assume there is only one FLAGS entry
+			has_origin_flag_1 = 'ORIGIN' in dynsect['FLAGS_1'][0]
+
+		# TODO: readelf version ref extraction
+		# regex is at the bottom of the class
+
+		return ElfInfo(
+			source=ElfInfoSource.READELF,
+			imported_libs=imported_libs,
+			has_origin_flag=has_origin_flag,
+			has_origin_flag_1=has_origin_flag_1
+		)
+
+	def _get_elfinfo_objdump(self, bin_path: str) -> ElfInfo:
+		raise NotImplementedError
+
+	def _get_elfinfo_lief(self, bin_path: str) -> ElfInfo:
+		lib = self.lief.parse(bin_path)
+
+		rpath = None
+		if lib.has(self.lief.ELF.DYNAMIC_TAGS.RPATH):
+			# Assume there is only one RPATH entry
+			rentry = lib.get(self.lief.ELF.DYNAMIC_TAGS.RPATH)
+			rpath = rentry.paths
+
+		runpath = None
+		if lib.has(self.lief.ELF.DYNAMIC_TAGS.RUNPATH):
+			# Assume there is only one RUNPATH entry
+			rentry = lib.get(self.lief.ELF.DYNAMIC_TAGS.RUNPATH)
+			runpath = rentry.paths
+
+		imported_libs = list(lib.libraries)
+
+		has_origin_flag = False
+		if lib.has(self.lief.ELF.DYNAMIC_TAGS.FLAGS):
+			# Assume there is only one FLAGS entry
+			fentry = lib.get(self.lief.ELF.DYNAMIC_TAGS.FLAGS)
+			has_origin_flag = int(self.lief.ELF.DYNAMIC_FLAGS.ORIGIN) in fentry.flags
+
+		has_origin_flag_1 = False
+		if lib.has(self.lief.ELF.DYNAMIC_TAGS.FLAGS_1):
+			# Assume there is only one FLAGS_1 entry
+			fentry = lib.get(self.lief.ELF.DYNAMIC_TAGS.FLAGS_1)
+			has_origin_flag_1 = int(self.lief.ELF.DYNAMIC_FLAGS_1.ORIGIN) in fentry.flags
+
+		version_refs = []
+		for verreq in lib.symbols_version_requirement:
+			reqentries = [e.name for e in verreq.get_auxiliary_symbols()]
+			version_refs.append(ElfVersionRefGroup(verreq.name, reqentries))
+
+		return ElfInfo(
+			source=ElfInfoSource.LIEF,
+			rpath=rpath,
+			runpath=runpath,
+			imported_libs=imported_libs,
+			has_origin_flag=has_origin_flag,
+			has_origin_flag_1=has_origin_flag_1,
+			version_refs=version_refs
+		)
+
+	def get_elfinfo(self, bin_path: str) -> ElfInfo:
+		if self.tool_state.readelf:
+			return self._get_elfinfo_readelf(bin_path)
+		elif self.tool_state.lief:
+			return self._get_elfinfo_lief(bin_path)
+		elif self.tool_state.objdump:
+			raise NotImplementedError('fetching elf info with objdump is not implemented')
+		else:
+			raise RuntimeError('get_elfinfo called but no tool available')
+
+	# readelf -W -V [lib]
+	# TODO: old llvm-readelf doesn't output GNU format for -V
+	_rp_readelf_v_line_ind = r'^(?<indent>[ \t]+)'
+
+	_rp_readelf_v_offset = r'(?P<offset>0x[0-9a-f]+):'
+	# eu-readelf does not add additional padding to verentries
+	_rp_readelf_v_pad = r'(?<spacing>[ \t]+)'
+	_rp_readelf_v_structver = r'Version:[ \t]+(?P<structver>\d+)'
+	_rp_readelf_v_implib = r'[ \t]+File:[ \t]+(?P<soname>[^><\s:]+)'
+	_rp_readelf_v_entqty = r'[ \t]+Cnt:[ \t]+(?P<entqty>\d+)'
+
+	_rp_readelf_v_name = r'Name:[ \t]+(?P<name>[^\s]+)'
+	# TODO: we don't actually know what flags look like when not none
+	# TODO: assume flags can have spaces in the value, but value will be followed by two spaces
+	_rp_readelf_v_flags = r'[ \t]+Flags:[ \t]+(?P<flags>[^\s]+)'
+	_rp_readelf_v_index = r'[ \t]+Version:[ \t]+(?P<index>\d+)'
+
+	# objdump -w -p [lib]
+	_rp_objdump_p_ind = r'^(?<indent>[ \t]*)'
+	_rp_objdump_p_line = r'(?P<line>[^\n]*)$'
+
+	# 'Dynamic Section:'
+	_rp_objdump_dynsect_tag_name = r'(?P<tag_name>[A-Z0-9_]+)'
+	_rp_objdump_dynsect_value = r'[ \t]+(?P<value>[^\n]*)$'
+
+	# 'Version References:'
+	_rp_objdump_verref_implib = r'required from (?P<soname>[^><\n:]+):$'
+	_rp_od_vr_ent_hash = r'(?P<hash>0x[0-9a-f]+)'
+	_rp_od_vr_ent_flags = r'[ \t]+(?P<flags>0x[0-9a-f]+)'
+	_rp_od_vr_ent_index = r'[ \t]+(?P<index>\d+)'
+	_rp_od_vr_ent_name = r'[ \t]+(?P<name>[^\s]+)'

--- a/packaging/userspace/externs_libs.common
+++ b/packaging/userspace/externs_libs.common
@@ -1,0 +1,34 @@
+# This file helps our userspace tarball packager identify irods-provided libraries
+# (irods-externals) in library dependency chains.
+#
+# Each line lists the name of a library with no file extension or soversion.
+# Blank lines are ignored.
+# Lines starting with # are ignored.
+#
+# RATIONALE: In order to support building the userspace package when irods or the icommands are
+# built against irods-externals in nonstandard locations, a list of library names is provided
+# to assist in identifying irods-externals libraries during packaging. The data in this file will
+# only be used if the packager detects a dependency on a library outside of /opt/irods-externals
+# and not listed in a relevant known_libs file. If the library is not listed here either, the
+# packager will scream about it and exclude it from packaging.
+#
+# This file contains directives that are more or less universal for all distros we might support
+
+libarchive
+libavrocpp
+libboost_atomic
+libboost_chrono
+libboost_filesystem
+libboost_iostreams
+libboost_program_options
+libboost_random
+libboost_regex
+libboost_signals
+libboost_system
+libboost_thread
+libboost_timer
+libc++
+libc++abi
+libfmt
+libnanodbc
+libzmq

--- a/packaging/userspace/known_libs.centos7
+++ b/packaging/userspace/known_libs.centos7
@@ -1,0 +1,33 @@
+# This file helps our userspace tarball packager figure out what distro-provided libraries should
+# be bundled with our icommands.
+#
+# Each line lists the soname of a library.
+# Lines starting with + denote a library that may be included.
+# Lines starting with - denote a library that must be excluded.
+# Blank lines are ignored.
+# Lines starting with # are ignored.
+#
+# RATIONALE: There is a need for userspace packages for environments in which the user may not be
+# authorized to install packages on the system. Therefore, we provide the option to bundle any
+# distro-provided dependencies that are not installed by default.
+# Unfortunately, we cannot detect whether or not a given library is installed by default without
+# introducing unreasonable package-time requirements.
+
+-libbz2.so.1
+-libcom_err.so.2
+-libcrypto.so.10
+-libgssapi_krb5.so.2
+-libk5crypto.so.3
+-libkeyutils.so.1
+-libkrb5.so.3
+-libkrb5support.so.0
+-liblzma.so.5
+-libpcre.so.1
+-libssl.so.10
+-libxml2.so.2
+
+# libtool-ltdl package is not installed by default
++libltdl.so.7
+
+# unixODBC package is not installed by default
++libodbc.so.2

--- a/packaging/userspace/known_libs.common
+++ b/packaging/userspace/known_libs.common
@@ -1,0 +1,36 @@
+# This file helps our userspace tarball packager figure out what distro-provided libraries should
+# be bundled with our icommands.
+#
+# Each line lists the soname of a library.
+# Lines starting with + denote a library that may be included.
+# Lines starting with - denote a library that must be excluded.
+# Blank lines are ignored.
+# Lines starting with # are ignored.
+#
+# RATIONALE: There is a need for userspace packages for environments in which the user may not be
+# authorized to install packages on the system. Therefore, we provide the option to bundle any
+# distro-provided dependencies that are not installed by default.
+# Unfortunately, we cannot detect whether or not a given library is installed by default without
+# introducing unreasonable package-time requirements.
+#
+# This file contains directives that are more or less universal for all distros we might support
+
+# libc (glibc for all current cases)
+-libc.so.6
+-libdl.so.2
+-libm.so.6
+-libresolv.so.2
+-librt.so.1
+-libpthread.so.0
+
+# zlib
+-libz.so.1
+
+# libgcc
+-libgcc_s.so.1
+
+# libstdc++
+-libstdc++.so.6
+
+# libselinux
+-libselinux.so.1

--- a/packaging/userspace/known_libs.ubuntu16
+++ b/packaging/userspace/known_libs.ubuntu16
@@ -1,0 +1,34 @@
+# This file helps our userspace tarball packager figure out what distro-provided libraries should
+# be bundled with our icommands.
+#
+# Each line lists the soname of a library.
+# Lines starting with + denote a library that may be included.
+# Lines starting with - denote a library that must be excluded.
+# Blank lines are ignored.
+# Lines starting with # are ignored.
+#
+# RATIONALE: There is a need for userspace packages for environments in which the user may not be
+# authorized to install packages on the system. Therefore, we provide the option to bundle any
+# distro-provided dependencies that are not installed by default.
+# Unfortunately, we cannot detect whether or not a given library is installed by default without
+# introducing unreasonable package-time requirements.
+
+-libbz2.so.1.0
+-liblzma.so.5
+
+# libssl package is not installed by default
++libcrypto.so.1.0.0
++libssl.so.1.0.0
+
+# libicu55 package is not installed by default
++libicudata.so.55
++libicuuc.so.55
+
+# libxml2 package is not installed by default
++libxml2.so.2
+
+# libltdl7 package is not installed by default
++libltdl.so.7
+
+# libodbc1 package is not installed by default
++libodbc.so.2

--- a/packaging/userspace/known_libs.ubuntu18
+++ b/packaging/userspace/known_libs.ubuntu18
@@ -1,0 +1,34 @@
+# This file helps our userspace tarball packager figure out what distro-provided libraries should
+# be bundled with our icommands.
+#
+# Each line lists the soname of a library.
+# Lines starting with + denote a library that may be included.
+# Lines starting with - denote a library that must be excluded.
+# Blank lines are ignored.
+# Lines starting with # are ignored.
+#
+# RATIONALE: There is a need for userspace packages for environments in which the user may not be
+# authorized to install packages on the system. Therefore, we provide the option to bundle any
+# distro-provided dependencies that are not installed by default.
+# Unfortunately, we cannot detect whether or not a given library is installed by default without
+# introducing unreasonable package-time requirements.
+
+-libbz2.so.1.0
+-liblzma.so.5
+
+# libssl package is not installed by default
++libcrypto.so.1.1
++libssl.so.1.1
+
+# libicu60 package is not installed by default
++libicudata.so.60
++libicuuc.so.60
+
+# libxml2 package is not installed by default
++libxml2.so.2
+
+# libltdl7 package is not installed by default
++libltdl.so.7
+
+# libodbc1 package is not installed by default
++libodbc.so.2

--- a/packaging/userspace/libdirectives.py
+++ b/packaging/userspace/libdirectives.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import logging  # noqa: I100,I202
+from abc import ABCMeta
+from collections.abc import Sized
+from os import path
+from typing import Optional
+
+from compat_shims import Container, Iterable, Mapping, MutableSequence, MutableSet, NoReturn
+from context import PackagerContext, PackagerOptionsBase
+from options import RunArgOption
+from utilbase import PackagerUtilBase
+
+__all__ = ['LibDirectiveOptionsBase', 'LibFsInfo', 'DirectiveLibSets', 'LibDirectives']
+
+
+class LibDirectiveOptionsBase(PackagerOptionsBase):  # pylint: disable=W0223
+	target_platform: Optional[str] = RunArgOption(
+		'--target-platform', metavar='PLATFORM',
+		action='store', opt_type=str, default=None
+	)
+	target_platform_variant: Optional[str] = RunArgOption(
+		'--target-platform-variant', metavar='VARIANT',
+		action='store', opt_type=str, default=None
+	)
+
+	permissive_liballowlist: MutableSequence[str] = RunArgOption(
+		'--permissive-lib-directives',
+		action='store_true', default=False,
+		help='Package libraries for which no directive is specified'
+	)
+
+
+class LibFsInfo(metaclass=ABCMeta):
+	"""
+	A class containing information about a library on the filesystem.
+
+	This handles a limited amount of symlink chicanery.
+	It does not handle linker script files, so libraries that use scripts in lieu
+	of symlinks (such as libc++.so) will be a problem.
+	"""
+
+	def __init__(self, soname: str, ld_path: str):
+		super().__init__()
+		self._soname = soname
+		self._ld_path = ld_path
+		self._links = {}
+
+		# For the time being, we only care about the soname->realpath linkage.
+		# We also make the assumption that soname symlinks and the actual
+		# libraries reside in the same directory, or that if they do not, it
+		# does not matter for our purposes.
+		self._real_path = path.realpath(ld_path)
+		self._fname = path.basename(self.real_path)
+		if soname != self.fname:
+			self._links[soname] = self.fname
+
+	@property
+	def soname(self) -> str:
+		return self._soname
+
+	@property
+	def fname(self) -> str:
+		return self._fname
+
+	@property
+	def real_path(self) -> str:
+		return self._real_path
+
+	@property
+	def ld_path(self) -> str:
+		return self._ld_path
+
+	@property
+	def links(self) -> Mapping[str, str]:
+		return self._links
+
+
+class DirectiveLibSets(Container, Sized):
+
+	def __init__(self,
+	             context: PackagerContext[LibDirectiveOptionsBase],
+	             sonames: Optional[Iterable[str]] = None,
+	             libnames: Optional[Iterable[str]] = None):
+		super().__init__()
+		self._context = context
+		self._sonames = set()
+		self._libnames = set()
+
+		if sonames:
+			self.sonames.update(sonames)
+		if libnames:
+			self.libnames.update(libnames)
+
+	@property
+	def context(self) -> PackagerContext[LibDirectiveOptionsBase]:
+		return self._context
+
+	@property
+	def sonames(self) -> MutableSet[str]:
+		return self._sonames
+
+	@property
+	def libnames(self) -> MutableSet[str]:
+		return self._libnames
+
+	def __contains__(self, lib: str) -> bool:
+		if lib in self.sonames or lib in self.libnames:
+			return True
+
+		# don't bother checking if a passed in soname maches a libname if the soname doesn't
+		# start with any of the libnames
+		skip_libname_check = True
+		for libname in self.libnames:
+			if lib.startswith(libname):
+				skip_libname_check = False
+				break
+		if skip_libname_check:
+			return False
+
+		# check if a passed in soname matches a libname
+		suffixes = self.context.options.sharedlib_suffixes
+		for suffix in suffixes:
+			# match libname.suffix to libname
+			if lib.endswith(suffix) and lib[:-len(suffix)] in self.libnames:
+				return True
+
+			# check for cases like libname.so.4.9.so.6.so (yes I have really seen this before)
+			# in such a case, we would match against libname, libname.so.4.9, & libname.so.4.9.so.6
+			suffixsep = suffix + '.'
+			splitlib = lib.split(suffixsep)
+			if len(splitlib) < 2:
+				continue
+			potential_libname = splitlib[0]
+			for libname_part in splitlib[1:]:
+				if potential_libname in self.libnames:
+					return True
+				potential_libname = potential_libname + suffixsep + libname_part
+
+		return False
+
+	def __len__(self) -> int:
+		sz = len(self.sonames) + len(self.libnames)
+		return sz
+
+
+class LibDirectives(PackagerUtilBase[LibDirectiveOptionsBase]):
+
+	def __init__(self, context: PackagerContext[LibDirectiveOptionsBase]):
+		super().__init__(context, None)
+		self._allowlist = DirectiveLibSets(context)
+		self._denylist = DirectiveLibSets(context)
+
+		target_platform = context.options.target_platform
+		target_platform_variant = context.options.target_platform_variant
+		if target_platform == 'none':
+			target_platform = None
+		if target_platform_variant in ('none', 'rolling'):
+			target_platform_variant = None
+		if target_platform and target_platform_variant:
+			target_platform = target_platform + target_platform_variant
+		self._target_platform = target_platform
+
+	def read_directives_for_target(self, target_name: str) -> NoReturn:
+		if not target_name:
+			return
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		libname_dfname = path.join(self.context.packager_dir, 'externs_libs.' + target_name)
+		soname_dfname = path.join(self.context.packager_dir, 'known_libs.' + target_name)
+
+		if path.exists(libname_dfname):
+			with open(libname_dfname, 'r') as directives_f:
+				for directive_l in directives_f:
+					if directive_l[0] == '#':
+						continue
+					directive_l = directive_l.rstrip()
+					if directive_l:
+						self.allowlist.libnames.add(directive_l)
+
+		if path.exists(soname_dfname):
+			with open(soname_dfname, 'r') as directives_f:
+				lnum = 0
+				for directive_l in directives_f:
+					lnum = lnum + 1
+					if directive_l[0] == '#':
+						continue
+					directive_l = directive_l.rstrip()
+					if not directive_l:
+						continue
+					elif directive_l[0] == '+':
+						soname = directive_l[1:]
+						self.denylist.sonames.discard(soname)
+						self.allowlist.sonames.add(soname)
+					elif directive_l[0] == '-':
+						soname = directive_l[1:]
+						self.allowlist.sonames.discard(soname)
+						self.denylist.sonames.add(soname)
+					else:
+						l.warning('%s:%s: Syntax error, ignoring line', soname_dfname, str(lnum))
+		else:
+			l.warning('No soname directives file for %s target_name. '
+			          'This will likely result in the exclusion of required libraries.',
+			          target_name)
+
+	def read_directives(self) -> NoReturn:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		l.info('reading known libs data')
+
+		self.read_directives_for_target(target_name='common')
+		self.read_directives_for_target(target_name=self.target_platform)
+
+	@property
+	def target_platform(self) -> Optional[str]:
+		return self._target_platform
+
+	@property
+	def allowlist(self) -> DirectiveLibSets:
+		return self._allowlist
+
+	@property
+	def denylist(self) -> DirectiveLibSets:
+		return self._denylist

--- a/packaging/userspace/lief_instrumentation.py
+++ b/packaging/userspace/lief_instrumentation.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import logging  # noqa: I100,I202
+from abc import abstractmethod
+from contextlib import suppress as suppress_ex
+from types import ModuleType
+from typing import Union
+
+import pkg_resources
+
+from compat_shims import NoReturn, Protocol
+from compat_shims import Version as PkgVersion
+
+try:
+	from lief import Binary as LiefBinT
+	from lief.ELF import Binary as LiefElfT
+except ImportError:
+	from typing import Any as LiefBinT
+	from typing import Any as LiefElfT
+
+
+__all__ = [
+	'lief_elf_module_proto',
+	'lief_module_proto',
+	'LiefElfModuleT',
+	'LiefModuleT',
+	'lief_ver_info'
+]
+
+
+class lief_elf_module_proto(Protocol):
+
+	@staticmethod
+	@abstractmethod
+	def parse(*args, **kwargs) -> LiefElfT:
+		raise NotImplementedError()
+
+
+LiefElfModuleT = Union[lief_elf_module_proto, ModuleType]
+
+
+class lief_module_proto(Protocol):
+
+	@staticmethod
+	@abstractmethod
+	def parse(*args, **kwargs) -> LiefBinT:
+		raise NotImplementedError()
+
+	@property
+	@staticmethod
+	@abstractmethod
+	def ELF() -> LiefElfModuleT:  # noqa: N802; pylint: disable=C0103
+		raise NotImplementedError
+
+
+LiefModuleT = Union[lief_module_proto, ModuleType]
+
+
+class lief_ver_info():
+	_min_req_ver = PkgVersion('0.10.0')
+	_min_rec_ver = PkgVersion('0.11.0')
+
+	_std_rebuild_size_warn_threshold = (36 * 1024 * 1024)
+	_slow_rebuild_size_warn_threshold = (16 * 1024 * 1024)
+
+	#@classmethod
+	@property
+	def minimum_required_version(cls) -> PkgVersion:
+		return cls._min_req_ver
+
+	#@classmethod
+	@property
+	def minimum_recommended_version(cls) -> PkgVersion:
+		return cls._min_rec_ver
+
+	@classmethod
+	def _get_lief_version(cls, lief: LiefElfModuleT) -> PkgVersion:
+		lief_ver_str_meta = None
+		lief_ver_str_tag = None
+		lief_ver_str_dunder = None
+
+		with suppress_ex(Exception):
+			return pkg_resources.get_distribution('lief').parsed_version
+
+		if hasattr(lief, '__tag__'):
+			with suppress_ex(Exception):
+				lief_ver_str_tag = lief.__tag__
+				return PkgVersion(lief_ver_str_tag)
+
+		if hasattr(lief, '__version__'):
+			with suppress_ex(Exception):
+				lief_ver_str_dunder = lief.__version__
+				return PkgVersion(lief_ver_str_tag)
+
+		if lief_ver_str_dunder:
+			with suppress_ex(Exception):
+				lief_ver_str_dunder = lief_ver_str_dunder.partition('-')[0]
+				return PkgVersion(lief_ver_str_dunder)
+
+		if lief_ver_str_meta:
+			with suppress_ex(Exception):
+				lief_ver_str_meta = lief_ver_str_meta.partition('-')[0]
+				return PkgVersion(lief_ver_str_meta)
+
+		return None
+
+	def __init__(self, lief: LiefElfModuleT):
+		self._lief: LiefElfModuleT = lief
+		self._lief_imported = False
+		self._lief_version = None
+		self._lief_usable = False
+		self._rebuild_is_slow = None
+		self._old_logger_api = None
+		self._not_threadsafe = None
+
+		if lief:
+			self._lief_imported = True
+			self._lief_version = self._get_lief_version(lief)
+			if self._lief_version is None:
+				self._lief_usable = True
+			elif self._lief_version < self.minimum_required_version:
+				self._lief_usable = False
+			elif self._lief_version < self.minimum_recommended_version:
+				self._lief_usable = True
+				self._rebuild_is_slow = True
+				self._old_logger_api = True
+				self._not_threadsafe = True
+			else:
+				self._lief_usable = True
+				self._rebuild_is_slow = False
+				self._old_logger_api = False
+				self._not_threadsafe = False
+
+	@property
+	def lief_imported(self) -> bool:
+		return self._lief_imported
+
+	@property
+	def lief_version(self) -> PkgVersion:
+		return self._lief_version
+
+	@property
+	def lief_usable(self) -> bool:
+		return self._lief_usable
+
+	@property
+	def rebuild_is_slow(self) -> bool:
+		return self._rebuild_is_slow
+
+	@property
+	def old_logger_api(self) -> bool:
+		return self._old_logger_api
+
+	@property
+	def not_threadsafe(self) -> bool:
+		return self._not_threadsafe
+
+	# Settable instance property because we might want to allow the value to be
+	# tweaked for specific operations
+	@property
+	def std_rebuild_size_warn_threshold(self) -> int:
+		return self._std_rebuild_size_warn_threshold
+	@std_rebuild_size_warn_threshold.setter  # noqa: E301
+	def std_rebuild_size_warn_threshold(self, value: int) -> NoReturn:
+		self._std_rebuild_size_warn_threshold = value
+
+	# Settable instance property because we might want to allow the value to be
+	# tweaked for specific operations
+	@property
+	def slow_rebuild_size_warn_threshold(self) -> int:
+		return self._slow_rebuild_size_warn_threshold
+	@slow_rebuild_size_warn_threshold.setter  # noqa: E301
+	def slow_rebuild_size_warn_threshold(self, value: int) -> NoReturn:
+		self._slow_rebuild_size_warn_threshold = value
+
+	@property
+	def rebuild_size_warn_threshold(self) -> int:
+		if self.rebuild_is_slow:
+			return self.slow_rebuild_size_warn_threshold
+		return self.std_rebuild_size_warn_threshold
+
+	def check_and_whine(self) -> NoReturn:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		if self.lief_version is None:
+			l.warning('lief version could not be detected. Caveat emptor.')
+		elif self.lief_version < self.minimum_required_version:
+			l.warning('lief version %s detected. Version %s or greater is required to enable '
+			          'lief functionality. Version %s or greater is strongly recommended.',
+			          str(self.lief_version), str(self.minimum_required_version),
+			          str(self.minimum_recommended_version))
+		elif self.lief_version < self.minimum_recommended_version:
+			l.warning('lief version %s detected. Version %s or greater is strongly recommended. '
+			          'Caveat emptor.', str(self.lief_version), str(self.minimum_recommended_version))
+
+	def init_logging(self, verbosity: int) -> NoReturn:
+		if not self.lief_usable:
+			return
+
+		lief = self._lief
+		lief_log_level_offset = -2
+
+		if self.old_logger_api:
+			verbosity = verbosity + lief_log_level_offset
+
+			lief.Logger.disable()
+			lief.Logger.enable()
+
+			# The old logging API makes absolutely no sense.
+			#lief.Logger.set_verbose_level(1)
+			lief.Logger.set_level(lief.LOGGING_LEVEL.UNKNOWN)
+
+			if verbosity == 0:
+				lief.Logger.set_level(lief.LOGGING_LEVEL.INFO)
+			elif verbosity == 1:
+				lief.Logger.set_level(lief.LOGGING_LEVEL.WARNING)
+			elif verbosity == 2:
+				lief.Logger.set_level(lief.LOGGING_LEVEL.ERROR)
+			elif verbosity >= 3:
+				lief.Logger.set_level(lief.LOGGING_LEVEL.DEBUG)
+		else:
+			verbosity = verbosity + lief_log_level_offset
+
+			lief.logging.disable()
+			lief.logging.enable()
+
+			if verbosity == -1:
+				lief.logging.set_level(lief.logging.LOGGING_LEVEL.WARNING)
+			elif verbosity == 0:
+				lief.logging.set_level(lief.logging.LOGGING_LEVEL.INFO)
+			elif verbosity == 1:
+				lief.logging.set_level(lief.logging.LOGGING_LEVEL.DEBUG)
+			elif verbosity >= 2:
+				lief.logging.set_level(lief.logging.LOGGING_LEVEL.TRACE)
+			else:
+				lief.logging.set_level(lief.logging.LOGGING_LEVEL.ERROR)

--- a/packaging/userspace/log_instrumentation.py
+++ b/packaging/userspace/log_instrumentation.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import os, shutil  # noqa: I100,I202; pylint: disable=C0410
+import ctypes  # noqa: I100
+import io
+import logging
+import multiprocessing
+import signal, traceback  # pylint: disable=C0410
+import textwrap
+from pprint import PrettyPrinter as _pprinter  # noqa: N813
+from typing import Any, Optional
+
+from compat_shims import NoReturn, Sequence
+
+__all__ = [
+	'TRACE',
+	'MESSAGE',
+	'STATUS',
+	'trace',
+	'message',
+	'status',
+	'LoggingColorFormatter',
+	'get_term_sz',
+	'PrettyPrinter',
+	'pformat',
+	'pprint',
+	'pformat_captioned',
+	'pprint_captioned',
+	'sizeof_fmt',
+	'dump_stacktrace',
+	'setup_stacktrace_signal',
+	'init_logging',
+]
+
+_logging_initialized = False  # pylint: disable=C0103
+
+TRACE   = logging.DEBUG - 5
+MESSAGE = logging.INFO  + 2
+STATUS  = logging.INFO  + 5
+
+
+def trace(logger: logging.Logger, msg: str, *args: Any, **kwargs: Any) -> NoReturn:
+	logger.log(TRACE, msg, *args, **kwargs)
+
+
+def message(logger: logging.Logger, msg: str, *args: Any, **kwargs: Any) -> NoReturn:
+	logger.log(MESSAGE, msg, *args, **kwargs)
+
+
+def status(logger: logging.Logger, msg: str, *args: Any, **kwargs: Any) -> NoReturn:
+	logger.log(STATUS, msg, *args, **kwargs)
+
+
+class LoggingColorFormatter(logging.Formatter):
+	STYLE_RESET_OFFSET = 20
+	ALL_RESET = 0
+
+	STYLE_BRIGHT    = 1
+	STYLE_DIM       = 2
+	STYLE_BLINK     = 4
+	STYLE_INVERT    = 7
+	STYLE_HIDE      = 8
+
+	STYLE_BRIGHT_RESET  = STYLE_RESET_OFFSET + STYLE_BRIGHT
+	STYLE_DIM_RESET     = STYLE_RESET_OFFSET + STYLE_DIM
+	STYLE_BLINK_RESET   = STYLE_RESET_OFFSET + STYLE_BLINK
+	STYLE_INVERT_RESET  = STYLE_RESET_OFFSET + STYLE_INVERT
+	STYLE_HIDE_RESET    = STYLE_RESET_OFFSET + STYLE_HIDE
+
+	FG_COLOR_START      = 30
+	BG_COLOR_START      = FG_COLOR_START + 10
+	COLOR_ALT_OFFSET    = 60
+
+	COLOR_IDX_RESET     = 9
+
+	COLOR_IDX_BLACK     = 0
+	COLOR_IDX_RED       = 1
+	COLOR_IDX_GREEN     = 2
+	COLOR_IDX_YELLOW    = 3
+	COLOR_IDX_BLUE      = 4
+	COLOR_IDX_MAGENTA   = 5
+	COLOR_IDX_CYAN      = 6
+	COLOR_IDX_LIGHTGRAY = 7
+
+	COLOR_IDX_DARKGRAY      = COLOR_ALT_OFFSET + COLOR_IDX_BLACK
+	COLOR_IDX_LIGHTRED      = COLOR_ALT_OFFSET + COLOR_IDX_RED
+	COLOR_IDX_LIGHTGREEN    = COLOR_ALT_OFFSET + COLOR_IDX_GREEN
+	COLOR_IDX_LIGHTYELLOW   = COLOR_ALT_OFFSET + COLOR_IDX_YELLOW
+	COLOR_IDX_LIGHTBLUE     = COLOR_ALT_OFFSET + COLOR_IDX_BLUE
+	COLOR_IDX_LIGHTMAGENTA  = COLOR_ALT_OFFSET + COLOR_IDX_MAGENTA
+	COLOR_IDX_LIGHTCYAN     = COLOR_ALT_OFFSET + COLOR_IDX_CYAN
+	COLOR_IDX_WHITE         = COLOR_ALT_OFFSET + COLOR_IDX_LIGHTGRAY
+
+	FG_RESET = FG_COLOR_START + COLOR_IDX_RESET
+
+	FG_BLACK        = FG_COLOR_START + COLOR_IDX_BLACK
+	FG_RED          = FG_COLOR_START + COLOR_IDX_RED
+	FG_GREEN        = FG_COLOR_START + COLOR_IDX_GREEN
+	FG_YELLOW       = FG_COLOR_START + COLOR_IDX_YELLOW
+	FG_BLUE         = FG_COLOR_START + COLOR_IDX_BLUE
+	FG_MAGENTA      = FG_COLOR_START + COLOR_IDX_MAGENTA
+	FG_CYAN         = FG_COLOR_START + COLOR_IDX_CYAN
+	FG_LIGHTGRAY    = FG_COLOR_START + COLOR_IDX_LIGHTGRAY
+	FG_DARKGRAY     = FG_COLOR_START + COLOR_IDX_DARKGRAY
+	FG_LIGHTRED     = FG_COLOR_START + COLOR_IDX_LIGHTRED
+	FG_LIGHTGREEN   = FG_COLOR_START + COLOR_IDX_LIGHTGREEN
+	FG_LIGHTYELLOW  = FG_COLOR_START + COLOR_IDX_LIGHTYELLOW
+	FG_LIGHTBLUE    = FG_COLOR_START + COLOR_IDX_LIGHTBLUE
+	FG_LIGHTMAGENTA = FG_COLOR_START + COLOR_IDX_LIGHTMAGENTA
+	FG_LIGHTCYAN    = FG_COLOR_START + COLOR_IDX_LIGHTCYAN
+	FG_WHITE        = FG_COLOR_START + COLOR_IDX_WHITE
+
+	BG_RESET = BG_COLOR_START + COLOR_IDX_RESET
+
+	BG_BLACK        = BG_COLOR_START + COLOR_IDX_BLACK
+	BG_RED          = BG_COLOR_START + COLOR_IDX_RED
+	BG_GREEN        = BG_COLOR_START + COLOR_IDX_GREEN
+	BG_YELLOW       = BG_COLOR_START + COLOR_IDX_YELLOW
+	BG_BLUE         = BG_COLOR_START + COLOR_IDX_BLUE
+	BG_MAGENTA      = BG_COLOR_START + COLOR_IDX_MAGENTA
+	BG_CYAN         = BG_COLOR_START + COLOR_IDX_CYAN
+	BG_LIGHTGRAY    = BG_COLOR_START + COLOR_IDX_LIGHTGRAY
+	BG_DARKGRAY     = BG_COLOR_START + COLOR_IDX_DARKGRAY
+	BG_LIGHTRED     = BG_COLOR_START + COLOR_IDX_LIGHTRED
+	BG_LIGHTGREEN   = BG_COLOR_START + COLOR_IDX_LIGHTGREEN
+	BG_LIGHTYELLOW  = BG_COLOR_START + COLOR_IDX_LIGHTYELLOW
+	BG_LIGHTBLUE    = BG_COLOR_START + COLOR_IDX_LIGHTBLUE
+	BG_LIGHTMAGENTA = BG_COLOR_START + COLOR_IDX_LIGHTMAGENTA
+	BG_LIGHTCYAN    = BG_COLOR_START + COLOR_IDX_LIGHTCYAN
+	BG_WHITE        = BG_COLOR_START + COLOR_IDX_WHITE
+
+	@classmethod
+	def get_sequence(cls, *args: Any) -> str:
+		if len(args) < 1:
+			return None
+		return '\033[' + ';'.join([str(arg) for arg in args]) + 'm'
+
+	def __init__(self, *args, **kwargs):  # noqa: ANN002,ANN003,ANN204
+		super().__init__(*args, **kwargs)
+		self.enabled = sys.stdout.isatty()
+		self.reset_all_seq = self.get_sequence(self.ALL_RESET)
+		self.critical_seq = self.get_sequence(self.STYLE_BRIGHT, self.FG_LIGHTRED, self.BG_DARKGRAY)
+		self.error_seq = self.get_sequence(self.STYLE_BRIGHT, self.FG_RED)
+		self.warning_seq = self.get_sequence(self.STYLE_BRIGHT, self.FG_YELLOW)
+		self.status_seq = self.get_sequence(self.STYLE_BRIGHT, self.FG_BLUE)
+		self.message_seq = self.get_sequence(self.STYLE_BRIGHT, self.FG_LIGHTGRAY)
+
+	def format(self, record: logging.LogRecord) -> str:  # noqa: A003
+		msg = super().format(record)
+
+		if not self.enabled:
+			return msg
+
+		if record.levelno >= logging.CRITICAL:
+			return self.critical_seq + msg + self.reset_all_seq
+		elif record.levelno >= logging.ERROR:
+			return self.error_seq + msg + self.reset_all_seq
+		elif record.levelno >= logging.WARNING:
+			return self.warning_seq + msg + self.reset_all_seq
+		elif record.levelno >= STATUS:
+			return self.status_seq + msg + self.reset_all_seq
+		elif record.levelno >= MESSAGE:
+			return self.message_seq + msg + self.reset_all_seq
+
+		return msg
+
+
+_last_term_sz = os.terminal_size((80, 24))
+
+
+def get_term_sz() -> os.terminal_size:
+	global _last_term_sz  # pylint: disable=C0103,W0603
+	_last_term_sz = shutil.get_terminal_size(_last_term_sz)
+	return _last_term_sz
+
+
+class PrettyPrinter(_pprinter):
+
+	def __init__(
+		self,
+		*args,  # noqa: ANN002
+		indent: int = 2,
+		width: Optional[int] = None,
+		caption_separator: str = ': ',
+		**kwargs  # noqa: ANN003
+	):
+		if width is None:
+			width = get_term_sz().columns
+
+		super().__init__(indent=indent, width=width, *args, **kwargs)
+
+		self._caption_separator = caption_separator
+
+	def pprint(self, obj: Any, *, flush: bool = False) -> NoReturn:  # noqa: T004; pylint: disable=W0221
+		super().pprint(obj)
+		if flush:
+			self._stream.flush()
+
+	def _pformat_captioned(self, cap: str, obj: Any) -> Sequence[str]:
+		cap = cap + self._caption_separator
+		indent_sz = len(cap)
+
+		prevwidth = self._width
+		try:
+			self._width = self._width - (indent_sz + 1)
+			if not self._width:
+				raise ValueError('_width == 0')
+			pfstrp = list(self.pformat(obj).rstrip().partition('\n'))
+		finally:
+			self._width = prevwidth
+
+		pfstrp[0] = cap + pfstrp[0]
+		if pfstrp[2]:
+			pfstrp[2] = textwrap.indent(pfstrp[2], ' ' * indent_sz)
+
+		return pfstrp
+
+	def pformat_captioned(self, caption: str, obj: Any) -> str:
+		pfstrp = self._pformat_captioned(caption, obj)
+		return ''.join(pfstrp)
+
+	def pprint_captioned(self, caption: str, obj: Any, flush: bool = False) -> NoReturn:
+		pfstrp = self._pformat_captioned(caption, obj)
+		for pfstr in pfstrp:
+			self._stream.write(pfstr)
+		self._stream.write('\n')
+		if flush:
+			self._stream.flush()
+
+
+def pformat(obj: Any, *args, **kwargs) -> str:  # noqa: ANN002,ANN003
+	pp = PrettyPrinter(*args, **kwargs)
+	return pp.pformat(obj)
+
+
+def pprint(obj: Any, *args, **kwargs) -> NoReturn:  # noqa: T004,ANN002,ANN003
+	pp = PrettyPrinter(*args, **kwargs)
+	pp.pprint(obj)
+
+
+def pformat_captioned(caption: str, obj: Any, *args, **kwargs) -> str:  # noqa: ANN002,ANN003
+	pp = PrettyPrinter(*args, **kwargs)
+	return pp.pformat_captioned(caption, obj)
+
+
+def pprint_captioned(caption: str, obj: Any, *args, **kwargs) -> NoReturn:  # noqa: ANN002,ANN003
+	pp = PrettyPrinter(*args, **kwargs)
+	pp.pprint_captioned(caption, obj)
+
+
+def sizeof_fmt(num: int, suffix: str = 'B') -> str:
+	for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+		if abs(num) < 1024.0:
+			return '%3.1f%s%s' % (num, unit, suffix)
+		num /= 1024.0
+	return '%.1f%s%s' % (num, 'Yi', suffix)
+
+
+def dump_stacktrace(sig, frame) -> NoReturn:  # noqa: ANN001
+	msgb = io.StringIO()
+	tid = ctypes.CDLL('libc.so.6').syscall(186)
+	msgb.write('Signal {0} received.\n'.format(sig))
+	msgb.write('PID: {0}; TID: {1}\n'.format(os.getpid(), tid))
+	msgb.write('Multiprocessing start method: {0}\n'.format(multiprocessing.get_start_method()))
+	msgb.write('Stacktrace:\n')
+	for fmt_stk in traceback.format_stack(frame):
+		msgb.write(fmt_stk)
+	print(msgb.getvalue(), file=sys.stderr)  # noqa: T001
+
+
+def setup_stacktrace_signal() -> NoReturn:
+	signal.signal(signal.SIGQUIT, dump_stacktrace)
+	#print('PID:', os.getpid(), file=sys.stderr)  # noqa: T001
+
+
+def init_logging(verbosity: int) -> NoReturn:
+	# we don't want redundant output, so make sure we don't initialize more than once
+	global _logging_initialized  # pylint: disable=C0103,W0603
+	if _logging_initialized:
+		return
+
+	log_level_offset = 0
+	verbosity = verbosity + log_level_offset
+
+	l = logging.getLogger()  # noqa: VNE001,E741
+
+	logging.addLevelName(STATUS, 'STATUS')
+	logging.addLevelName(MESSAGE, 'MESSAGE')
+	logging.addLevelName(TRACE, 'TRACE')
+
+	l.setLevel(logging.NOTSET)
+
+	formatter = LoggingColorFormatter()
+
+	err_handler = logging.StreamHandler(sys.stderr)
+	err_handler.setFormatter(formatter)
+
+	info_handler = logging.StreamHandler(sys.stdout)
+	info_handler.setFormatter(formatter)
+	info_handler.addFilter(lambda rec: 1 if rec.levelno < logging.WARNING else 0)
+	info_handler.setLevel(logging.CRITICAL)
+
+	trace_handler = logging.StreamHandler(sys.stderr)
+	trace_handler.setFormatter(formatter)
+	trace_handler.addFilter(lambda rec: 1 if rec.levelno < logging.INFO else 0)
+	trace_handler.setLevel(logging.CRITICAL)
+
+	err_handler.setLevel(logging.ERROR)
+	if verbosity >= -2:
+		err_handler.setLevel(logging.WARNING)
+	if verbosity == -1:
+		info_handler.setLevel(STATUS)
+	elif verbosity == 0:
+		info_handler.setLevel(MESSAGE)
+	elif verbosity >= 1:
+		info_handler.setLevel(logging.INFO)
+	if verbosity == 2:
+		trace_handler.setLevel(logging.DEBUG)
+	elif verbosity == 3:
+		trace_handler.setLevel(TRACE)
+	elif verbosity >= 4:
+		trace_handler.setLevel(logging.NOTSET)
+	if verbosity == 5:
+		import multiprocessing.util as multiproc_util
+		multiproc_util.log_to_stderr(logging.NOTSET)
+
+	l.addHandler(err_handler)
+	l.addHandler(info_handler)
+	l.addHandler(trace_handler)
+
+	_logging_initialized = True

--- a/packaging/userspace/options.py
+++ b/packaging/userspace/options.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import argparse  # noqa: I100,I202
+from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
+from typing import Any, Optional, Union
+
+from compat_shims import Mapping, Sequence, Type
+
+__all__ = [
+	'_IncrDecrAction',
+	'IncrementAction',
+	'DecrementAction',
+	'ArgparseActor',
+	'RunArgGroup',
+	'RunOption',
+	'RunArgBase',
+	'RunArgOption',
+	'RunWhininessArg',
+	'RunOptsContainer'
+]
+
+
+class _IncrDecrAction(argparse.Action):
+	def __init__(
+		self,
+		option_strings,
+		dest,
+		nargs=None,
+		const=None,
+		default=None,
+		type=None,  # noqa: A002,VNE003; pylint: disable=W0622
+		choices=None,
+		required=False,
+		metavar=None,
+		**kwargs
+	):
+		if nargs is not None and nargs != 0:
+			raise ValueError('nonzero nargs not allowed')
+		if const is not None:
+			raise ValueError('const not allowed')
+		if type is not None and type != int:
+			raise ValueError('non-int type not allowed')
+		if choices is not None:
+			raise ValueError('choices not allowed')
+		if required:
+			raise ValueError('non-false required not allowed')
+		if metavar is not None:
+			raise ValueError('metavar not allowed')
+
+		if default is None:
+			default = 0
+
+		super().__init__(option_strings, dest, nargs=0, default=0, type=int, **kwargs)
+
+	@abstractmethod
+	def __call__(self, parser, namespace, values, option_string=None):
+		raise NotImplementedError()
+
+
+class IncrementAction(_IncrDecrAction):
+
+	def __call__(self, parser, namespace, values, option_string=None):
+		setattr(namespace, self.dest, getattr(namespace, self.dest, self.default) + 1)
+
+
+class DecrementAction(_IncrDecrAction):
+
+	def __call__(self, parser, namespace, values, option_string=None):
+		setattr(namespace, self.dest, getattr(namespace, self.dest, self.default) - 1)
+
+
+class ArgparseActor(metaclass=ABCMeta):
+
+	@abstractmethod
+	def add_to_argparser(self, argparser: argparse.ArgumentParser, owner):
+		raise NotImplementedError()
+
+	def cleanup_container(self, owner):
+		pass
+
+
+class RunArgGroup(ArgparseActor):
+	def __init__(
+		self,
+		title: Optional[str] = None,
+		description: Optional[str] = None
+	):
+		super().__init__()
+		self.title: Optional[str] = title
+		self.description: Optional[str] = description
+
+	def __set_name__(self, owner, name: str):
+		self.public_name: str = name
+		self.private_name: str = '_argparse_group_' + name
+
+	def __get__(self, obj, objtype=None):
+		if obj is None:
+			return self
+		return getattr(obj, self.private_name, None)
+
+	def add_to_argparser(self, argparser: argparse.ArgumentParser, owner):
+		group = getattr(owner, self.private_name, None)
+		if group and group in argparser._action_groups:  # pylint: disable=W0212
+			return group
+		group = argparser.add_argument_group(title=self.title, description=self.description)
+		setattr(owner, self.private_name, group)
+		return group
+
+	def cleanup_container(self, owner):
+		if hasattr(owner, self.private_name):
+			delattr(owner, self.private_name)
+
+
+class RunOption(metaclass=ABCMeta):
+	def __init__(
+		self,
+		opt_type: Optional[Type] = None,
+		default: Optional[Any] = None
+	):
+		super().__init__()
+		self.opt_type: Optional[Type] = opt_type
+		self.default: Optional[Any] = default
+
+	def __set_name__(self, owner, name: str):
+		self.public_name: str = name
+		self.private_name: str = '_' + name
+
+	def __get__(self, obj, objtype=None):
+		if obj is None:
+			return self
+		return getattr(obj, self.private_name, self.default)
+
+	def __set__(self, obj, value):
+		setattr(obj, self.private_name, value)
+
+
+class RunArgBase(ArgparseActor):
+	def __init__(
+		self,
+		*args: str,
+		group: Optional[RunArgGroup] = None,
+		action: Optional[Union[str, Type[argparse.Action]]] = None,
+		nargs: Optional[Union[str, int]] = None,
+		help: Optional[str] = None  # noqa: A002; pylint: disable=W0622
+	):
+		super().__init__()
+		self.args: Sequence[str] = args
+		self.group: Optional[RunArgGroup] = group
+		self.action: Optional[Union[str, Type[argparse.Action]]] = action
+		self.nargs: Optional[Union[str, int]] = nargs
+		self.help: Optional[str] = help
+
+	@abstractmethod
+	def add_to_argparser(self, argparser: argparse.ArgumentParser, owner):
+		raise NotImplementedError()
+
+
+class RunArgOption(RunOption, RunArgBase):
+	def __init__(
+		self,
+		*args: str,
+		metavar: Optional[str] = None,
+		group: Optional[RunArgGroup] = None,
+		action: Optional[Union[str, Type[argparse.Action]]] = None,
+		opt_type: Optional[Type] = None,
+		nargs: Optional[Union[str, int]] = None,
+		default: Optional[Any] = None,
+		help: Optional[str] = None  # noqa: A002; pylint: disable=W0622
+	):
+		RunOption.__init__(self, opt_type=opt_type, default=default)
+		RunArgBase.__init__(self, group=group, action=action, nargs=nargs, help=help, *args)
+		self.metavar: Optional[str] = metavar
+
+	def add_to_argparser(self, argparser: argparse.ArgumentParser, owner):
+		group = argparser
+		if self.group:
+			group = self.group.add_to_argparser(argparser, owner)
+		args = self.args
+		kwargs = {}
+		if self.metavar:
+			kwargs['metavar'] = self.metavar
+		if self.action:
+			kwargs['action'] = self.action
+		kwargs['dest'] = self.public_name
+		if self.opt_type:
+			kwargs['type'] = self.opt_type
+		if self.nargs:
+			kwargs['nargs'] = self.nargs
+		if self.default:
+			kwargs['default'] = self.default
+		if self.help:
+			kwargs['help'] = self.help
+		return group.add_argument(*args, **kwargs)
+
+	def cleanup_container(self, owner):
+		if self.group:
+			self.group.cleanup_container(owner)
+
+
+class RunWhininessArg(RunArgBase):
+	def __init__(
+		self,
+		*args: str,
+		group: Optional[RunArgGroup] = None,
+		action: Type[_IncrDecrAction] = None,
+		dest: Union[str, RunOption] = None,
+		help: Optional[str] = None  # noqa: A002; pylint: disable=W0622
+	):
+		super().__init__(group=group, action=action, help=help, *args)
+		self.dest: Union[str, RunOption] = dest
+
+	def add_to_argparser(self, argparser: argparse.ArgumentParser, owner):
+		group = argparser
+		if self.group:
+			group = self.group.add_to_argparser(argparser, owner)
+		args = self.args
+		kwargs = {}
+		kwargs['action'] = self.action
+		kwargs['dest'] = self.dest.public_name
+		kwargs['type'] = int
+		if self.help:
+			kwargs['help'] = self.help
+		return group.add_argument(*args, **kwargs)
+
+	def cleanup_container(self, owner):
+		if self.group:
+			self.group.cleanup_container(owner)
+
+
+class RunOptsContainer(metaclass=ABCMeta):
+
+	def __new__(cls):
+		obj = super().__new__(cls)
+
+		_mro = list(cls.mro())
+		while _mro[-1] != RunOptsContainer:
+			_mro.pop()
+		_mro.reverse()
+
+		_groupsdict = OrderedDict()
+		_argsdict = OrderedDict()
+		_optsdict = OrderedDict()
+		_actordict = OrderedDict()
+		for scls in _mro:
+			for name, attr in scls.__dict__.items():
+				if isinstance(attr, RunArgGroup):
+					_groupsdict[name] = attr
+				if isinstance(attr, RunArgBase):
+					_argsdict[name] = attr
+				if isinstance(attr, RunOption):
+					_optsdict[name] = attr
+				if isinstance(attr, ArgparseActor):
+					_actordict[name] = attr
+
+		cls._groupsdict: Mapping[str, RunArgGroup] = _groupsdict
+		cls._argsdict: Mapping[str, RunArgBase] = _argsdict
+		cls._optsdict: Mapping[str, RunOption] = _optsdict
+		cls._actordict: Mapping[str, ArgparseActor] = _actordict
+
+		return obj
+
+	def __contains__(self, key: str) -> bool:
+		return key in self._optsdict
+
+	def __repr__(self) -> str:
+		type_name = type(self).__name__
+		arg_strings = []
+		star_args = {}
+		for name in self._optsdict.keys():
+			value = getattr(self, name)
+			if name.isidentifier():
+				arg_strings.append('%s=%r' % (name, value))
+			else:
+				star_args[name] = value
+		if star_args:
+			arg_strings.append('**%s' % repr(star_args))
+		return '%s(%s)' % (type_name, ', '.join(arg_strings))
+
+	@abstractmethod
+	def create_empty_argparser(self) -> argparse.ArgumentParser:
+		raise NotImplementedError
+
+	def parse_args(self, args: Optional[Sequence[str]] = None):
+		argparser = self.create_empty_argparser()
+		for actor in self._actordict.values():
+			actor.add_to_argparser(argparser, self)
+		argparser.parse_args(args=args, namespace=self)
+		for actor in self._actordict.values():
+			actor.cleanup_container(self)
+		return self

--- a/packaging/userspace/pyproject.toml
+++ b/packaging/userspace/pyproject.toml
@@ -1,0 +1,394 @@
+[tool.poetry.dependencies]
+python = '^3.6'
+setuptools = { version = '>= 20.7' }
+distro = { version = '>= 0.6', python = '^3.8' }
+lief = { version = '>= 0.10', optional = true }
+
+[tool.pylint]
+	[tool.pylint.MASTER]
+	jobs = 1
+	load-plugins = [
+		'pylint.extensions.bad_builtin',
+		'pylint.extensions.broad_try_clause',
+		'pylint.extensions.check_elif',
+		'pylint.extensions.empty_comment',
+		'pylint.extensions.mccabe',
+		'pylint.extensions.overlapping_exceptions',
+		'pylint.extensions.redefined_variable_type',
+		# confusing_elif and typing not added until 2.8, codacy uses 2.7.4
+		#'pylint.extensions.confusing_elif',
+		#'pylint.extensions.typing',
+		# site packages
+		#'pylint_enums',
+		#'pylintfileheader',
+		#'sentry_stack_checker',
+	]
+	suggestion-mode = 'yes'
+
+	[tool.pylint.'MESSAGES CONTROL']
+	confidence = ''
+	enable = [
+		'all',
+		'parameter-unpacking',
+		'unpacking-in-except',
+		'old-raise-syntax',
+		'backtick',
+		'long-suffix',
+		'old-ne-operator',
+		'old-octal-literal',
+		'import-star-module-level',
+		'non-ascii-bytes-literal',
+		'raw-checker-failed',
+		'bad-inline-option',
+		'file-ignored',
+		'deprecated-pragma',
+		'apply-builtin',
+		'basestring-builtin',
+		'buffer-builtin',
+		'cmp-builtin',
+		'coerce-builtin',
+		'execfile-builtin',
+		'file-builtin',
+		'long-builtin',
+		'raw_input-builtin',
+		'reduce-builtin',
+		'standarderror-builtin',
+		'unicode-builtin',
+		'xrange-builtin',
+		'coerce-method',
+		'delslice-method',
+		'getslice-method',
+		'setslice-method',
+		'old-division',
+		'dict-iter-method',
+		'dict-view-method',
+		'next-method-called',
+		'metaclass-assignment',
+		'indexing-exception',
+		'raising-string',
+		'reload-builtin',
+		'oct-method',
+		'hex-method',
+		'nonzero-method',
+		'cmp-method',
+		'input-builtin',
+		'round-builtin',
+		'intern-builtin',
+		'unichr-builtin',
+		'map-builtin-not-iterating',
+		'zip-builtin-not-iterating',
+		'range-builtin-not-iterating',
+		'filter-builtin-not-iterating',
+		'using-cmp-argument',
+		'eq-without-hash',
+		'div-method',
+		'idiv-method',
+		'rdiv-method',
+		'exception-message-attribute',
+		'invalid-str-codec',
+		'sys-max-int',
+		'bad-python3-import',
+		'deprecated-string-function',
+		'deprecated-str-translate-call',
+		'deprecated-itertools-function',
+		'deprecated-types-field',
+		'next-method-defined',
+		'deprecated-operator-function',
+		'deprecated-urllib-function',
+		'xreadlines-attribute',
+		'deprecated-sys-function',
+		'exception-escape',
+		'comprehension-escape',
+	]
+	disable = [
+		'mixed-indentation',
+		'wrong-import-position',
+		'bad-continuation',
+		'bad-indentation',
+		'missing-docstring',
+		'missing-module-docstring',
+		'missing-class-docstring',
+		'missing-function-docstring',
+		'use-symbolic-message-instead',
+		'suppressed-message',
+		'useless-suppression',
+		'locally-disabled',
+		'no-absolute-import',
+		'import-outside-toplevel',
+		'wrong-import-order',
+		'dict-items-not-iterating',
+		'dict-keys-not-iterating',
+		'dict-values-not-iterating',
+		# pyflakes gets these for us
+		'unused-import',
+		'function-redefined',
+		# leave these uncommented for codacy, but toggle them as needed
+		'no-else-return',
+		'no-else-raise',
+		'no-else-continue',
+		'duplicate-code',
+	]
+
+	[tool.pylint.REFACTORING]
+	max-nested-blocks = 10
+	never-returning-functions = [ 'sys.exit' ]
+
+	[tool.pylint.LOGGING]
+	logging-format-style = 'old'
+	logging-modules = [ 'logging', 'log_instrumentation' ]
+
+	[tool.pylint.VARIABLES]
+	allow-global-unused-variables = 'yes'
+	allowed-redefined-builtins = []
+	init-import = 'no'
+	redefining-builtins-modules = [
+		'six.moves',
+		'past.builtins',
+		'future.builtins',
+		'builtins',
+		'io',
+	]
+
+	[tool.pylint.BASIC]
+	argument-naming-style = 'snake_case'
+	attr-naming-style = 'snake_case'
+	bad-names = []
+	bad-names-rgxs = []
+	class-attribute-naming-style = 'any'
+	class-const-naming-style = 'UPPER_CASE'
+	class-naming-style = 'PascalCase'
+	const-naming-style = 'UPPER_CASE'
+	function-naming-style = 'snake_case'
+	good-names = [
+		'i',
+		'j',
+		'k',
+		'l',
+		'ex',
+		'_',
+		'fn',
+		'sz',
+		'pp',
+	]
+	include-naming-hint = 'yes'
+	inlinevar-naming-style = 'any'
+	method-naming-style = 'snake_case'
+	module-naming-style = 'snake_case'
+	property-classes = [ 'abc.abstractproperty' ]
+	variable-naming-style = 'snake_case'
+
+	[tool.pylint.TYPECHECK]
+	contextmanager-decorators = [ 'contextlib.contextmanager' ]
+	generated-members = []
+	ignore-none = 'yes'
+	ignore-on-opaque-inference = 'yes'
+	ignored-classes = []
+	ignored-modules = []
+	missing-member-hint = 'yes'
+
+	[tool.pylint.FORMAT]
+	expected-line-ending-format = ''
+	indent-string = '\t'
+	max-line-length = 120  # Give pylint a larger margin so codacy doesn't flag
+	max-module-lines = 3000
+	single-line-class-stmt = 'no'
+	single-line-if-stmt = 'no'
+
+	[tool.pylint.STRING]
+	check-quote-consistency = 'yes'
+	check-str-concat-over-line-jumps = 'no'
+
+	[tool.pylint.MISCELLANEOUS]
+	notes = [
+		'FIXME',
+		'TODO',
+		'HACK',
+		'KLUDGE',
+		'BUG',
+		'OPTIMIZE',
+		'XXX',
+		'JANK',
+		'AWFUL',
+		'BAD',
+		'CRIME',
+		'CRIMES',
+	]
+
+	[tool.pylint.DESIGN]
+	max-args = 20
+	max-attributes = 100
+	max-bool-expr = 4
+	max-branches = 100
+	max-locals = 5000
+	max-parents = 100
+	max-public-methods = 100
+	max-returns = 100
+	max-statements = 5000
+	min-public-methods = 0
+	max-complexity = 20
+
+	[tool.pylint.TYPING]
+	py-version = '3.6'
+	runtime-typing = 'yes'
+
+	[tool.pylint.PYLINTFILEHEADER]
+	file-header = '#!/usr/bin/env python3?\n# -\*- coding: utf-8 -\*-'
+
+	[tool.pylint.SENTRY-STACK-CHECKER]
+	report-loggers = [
+		'debug',
+		'info',
+		'warning',
+		'error',
+		'critical',
+		'trace',
+		'message',
+	]
+
+	[tool.pylint.CLASSES]
+	check-protected-access-in-special-methods = 'yes'
+	defining-attr-methods = [
+		'__init__',
+		'__new__',
+		'__enter__',
+		'__post_init__',
+		'__set_name__',
+		'__init_subclass__',
+	]
+	exclude-protected = []
+	valid-classmethod-first-arg = [ 'cls', 'mcls', 'scls' ]
+	valid-metaclass-classmethod-first-arg = [ 'cls', 'mcls', 'scls' ]
+
+	[tool.pylint.IMPORTS]
+	allow-wildcard-with-all = 'no'
+	analyse-fallback-blocks = 'no'
+	deprecated-modules = [ 'optparse', 'tkinter.tix' ]
+	known-standard-library = ''
+	known-third-party = ''
+	preferred-modules = []
+
+	[tool.pylint.BROAD_TRY_CLAUSE]
+	max-try-statements = 5
+
+[tool.pydocstyle]
+ignore = [
+	# D100: Missing docstring in public module
+	'D100',
+	# D101: Missing docstring in public class
+	'D101',
+	# D102: Missing docstring in public method
+	'D102',
+	# D103: Missing docstring in public function
+	'D103',
+	# D104: Missing docstring in public package
+	'D104',
+	# D105: Missing docstring in magic method
+	'D105',
+	# D106: Missing docstring in public nested class
+	'D106',
+	# D107: Missing docstring in __init__
+	'D107',
+]
+
+[tool.flakehell]
+min-python-version = '3.6.0'
+mypy-init-return = true
+max_line_length = 100
+show_source = false
+#format = 'colored'
+format = 'grouped'
+application-package-names = [ 'irods' ]
+import-order-style = 'pycharm'
+application-import-names = [
+	'compat_shims',
+	'context',
+	'elfinfo_utils',
+	'libdirectives',
+	'lief_instrumentation',
+	'log_instrumentation',
+	'options',
+	'runpath_util',
+	'script_common',
+	'strip_util',
+	'tar_util',
+	'utilbase',
+]
+
+[tool.flakehell.plugins]
+pylint = [ '+*' ]
+pyflakes = [ '+*' ]
+pycodestyle = [
+	'+*',
+	# E101: indentation contains mixed spaces and tabs
+	# Tabs for indentation, spaces for alignment.
+	'-E101',
+	# E128: continuation line under-indented for visual indent
+	# Don't hate me cuz I'm pretty.
+	'-E128',
+	# E4??: import stuff
+	# We are managing imports with a different plugin
+	'-E4??',
+	# W191: indentation includes tabs
+	# Yes. It does.
+	'-W191',
+]
+'flake8-*' = [ '+*' ]
+hacking-core = [
+	'+*',
+	# H101: Use TODO(NAME)
+	# pylint handles TODO. git handles authorship
+	'-H101:',
+	# H106: Don't put vim configuration in source files
+	'-H106:',
+	# H238: old style class declaration, use new style (inherit from `object`) [hac
+	# Do not require explicit inheritance from object
+	'-H238:',
+	# H3??: import stuff
+	# We are managing imports with a different plugin
+	'-H3??:',
+	# H903:  Windows style line endings not allowed in code
+	# git can mess with this
+	'-H903:',
+]
+flake8-annotations = [
+	'+*',
+	# ANN101: Missing type annotation for self in method
+	'-ANN101',
+	# ANN102: Missing type annotation for cls in classmethod
+	'-ANN102',
+]
+flake8-docstrings = [
+	'+*',
+	# D1??: Missing docstring
+	'-D1??',
+]
+flake8-executable = [
+	'+*',
+	# EXE001: Shebang is present but the file is not executable
+	'-EXE001',
+]
+flake8-multiline-containers = [
+	'+*',
+	# JS102: Multi-line container does not close on same column as opening
+	'-JS102',
+]
+flake8-simplify = [
+	'+*',
+	# SIM106: Handle error-cases first
+	'-SIM106',
+]
+flake8-typing-imports = [
+	'+*',
+	# TYP002: @overload is broken in <3.5.2, add `if sys.version_info < (3, 5, 2): def overload(f): return f`
+	'-TYP002',
+]
+flake8-black = [ '-*' ]
+flake8-commas = [ '-*' ]
+flake8-fixme = [ '-*' ]
+flake8-isort = [ '-*' ]
+
+[tool.flakehell.exceptions."log_instrumentation.py"]
+pycodestyle = [ '-E221' ]  # multiple spaces before operator
+
+[tool.flakehell.exceptions."compat_shims.py"]
+pycodestyle = [ '-E301' ]  # expected x blank lines, found y

--- a/packaging/userspace/runpath_util.py
+++ b/packaging/userspace/runpath_util.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import shutil, sys, os, stat  # pylint: disable=C0410
+import argparse  # noqa: I100
+import errno
+import itertools
+import logging
+import tempfile
+from concurrent.futures import Executor, Future
+from os import path
+from typing import Generic, Optional, Union, overload
+
+import log_instrumentation as logging_ex
+from compat_shims import Iterable, Mapping, MutableSequence, Tuple
+from context import PackagerContext, PackagerOptionsBase, augment_module_search_paths
+from options import RunArgOption
+from utilbase import PackagerOperationToolState, PackagerToolState, PackagerUtilBase, ToolStateT
+
+__all__ = [
+	'RunpathUtil',
+	'RunpathUtilOptionsBase',
+	'RunpathToolStateBase',
+	'RunpathToolState',
+	'RunpathOperationState'
+]
+
+
+class RunpathUtilOptionsBase(PackagerOptionsBase):  # pylint: disable=W0223
+	chrpath_path: Optional[str] = RunArgOption(
+		'--chrpath-path', metavar='TOOLPATH',
+		group=PackagerOptionsBase.tool_args,
+		action='store', opt_type=str, default=None,
+		help='Path to chrpath tool to use'
+	)
+	cmake_path: Optional[str] = RunArgOption(
+		'--cmake-path', metavar='TOOLPATH',
+		group=PackagerOptionsBase.tool_args,
+		action='store', opt_type=str, default=None,
+		help='Path to cmake tool to use'
+	)
+
+	set_origin_flag: Optional[bool] = RunArgOption(
+		'--set-origin-flag', metavar='BOOL',
+		action='store', opt_type=bool, default=None,
+		help='Whether or not to set DF_ORIGIN flag'
+	)
+
+
+class RunpathUtilOptions(RunpathUtilOptionsBase):
+	output_path: Optional[str] = RunArgOption(
+		'-o', '--output', metavar='PATH',
+		action='store', default=None,
+		help='Place stripped output into PATH'
+	)
+
+	runpath: str = RunArgOption(
+		metavar='RUNPATH',
+		action='store', default=None
+	)
+	libraries: MutableSequence[str] = RunArgOption(
+		metavar='FILE', nargs='+',
+		action='store', opt_type=str, default=None
+	)
+
+	def create_empty_argparser(self) -> argparse.ArgumentParser:
+		return argparse.ArgumentParser(
+			description='Set RUNPATH and set DF_ORIGIN if needed',
+			allow_abbrev=False
+		)
+
+
+class RunpathToolStateBase(Generic[ToolStateT]):
+
+	def __init__(
+		self,
+		lief_tool: ToolStateT,
+		chrpath_tool: ToolStateT,
+		cmake_tool: ToolStateT
+	):
+		self._lief_tool = lief_tool
+		self._chrpath_tool = chrpath_tool
+		self._cmake_tool = cmake_tool
+
+	@property
+	def lief_tool(self) -> ToolStateT:
+		return self._lief_tool
+
+	@property
+	def lief(self) -> ToolStateT:
+		return self.lief_tool
+
+	@property
+	def chrpath_tool(self) -> ToolStateT:
+		return self._chrpath_tool
+
+	@property
+	def chrpath(self) -> ToolStateT:
+		return self.chrpath_tool
+
+	@property
+	def cmake_tool(self) -> ToolStateT:
+		return self._cmake_tool
+
+	@property
+	def cmake(self) -> ToolStateT:
+		return self.cmake_tool
+
+	def __bool__(self) -> bool:
+		return bool(self.lief_tool or self.chrpath_tool or self.cmake_tool)
+
+
+class RunpathToolState(RunpathToolStateBase[PackagerToolState]):
+	pass
+
+
+class RunpathOperationState(RunpathToolStateBase[PackagerOperationToolState]):
+
+	def __init__(self, tool_state: RunpathToolState):
+		lief_tool = PackagerOperationToolState(tool_state.lief_tool)
+		chrpath_tool = PackagerOperationToolState(tool_state.chrpath_tool)
+		cmake_tool = PackagerOperationToolState(tool_state.cmake_tool)
+		super().__init__(lief_tool, chrpath_tool, cmake_tool)
+
+
+# TODO: skip runpath setting if no direct dependencies are in tarball?
+class RunpathUtil(PackagerUtilBase[RunpathUtilOptionsBase]):
+
+	def __init__(
+		self,
+		context: PackagerContext[RunpathUtilOptionsBase],
+		executor: Optional[Executor] = None
+	):
+		super().__init__(context, executor)
+
+		env = self.fill_out_envdict()
+
+		chrpath_path = self.find_tool(
+			['chrpath'],
+			self.options.chrpath_path,
+			raise_if_not_found=False,
+			env=env
+		)
+		cmake_path = self.find_tool(
+			['cmake'],
+			self.options.cmake_path,
+			raise_if_not_found=False,
+			env=env
+		)
+
+		if self.options.set_origin_flag is None:
+			self.options.set_origin_flag = True
+
+		self._tool_state = RunpathToolState(
+			PackagerToolState(is_usable=self.lief_info.lief_usable),
+			PackagerToolState(is_usable=bool(chrpath_path), path=chrpath_path),
+			PackagerToolState(is_usable=bool(cmake_path), path=cmake_path)
+		)
+
+	@property
+	def tool_state(self) -> RunpathToolState:
+		return self._tool_state
+
+	def _set_rpath_lief(
+		self,
+		bin_path: str,
+		runpath: Optional[str],
+		set_origin: bool,
+		output_path: str,
+		inplace: bool,
+		op_state: RunpathOperationState
+	) -> str:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		lief = self.lief
+		fname = path.basename(bin_path)
+
+		# a little insurance, helps if operating inplace
+		tmp_out_fd, tmp_out = tempfile.mkstemp(
+			suffix=self.options.sharedlib_suffixes[0],
+			prefix=fname + '.',
+			dir=self.options.cmake_tmpdir
+		)
+		os.close(tmp_out_fd)
+		if path.exists(tmp_out):
+			os.unlink(tmp_out)
+		try:  # pylint: disable=W0717
+			lib = lief.parse(bin_path)
+			if set_origin:
+				if lib.has(lief.ELF.DYNAMIC_TAGS.FLAGS):
+					ent_flags = lib.get(lief.ELF.DYNAMIC_TAGS.FLAGS)
+					ent_flags.add(lief.ELF.DYNAMIC_FLAGS.ORIGIN)
+				else:
+					ent_flags = lief.ELF.DynamicEntryFlags(
+						lief.ELF.DYNAMIC_TAGS.FLAGS,
+						int(lief.ELF.DYNAMIC_FLAGS.ORIGIN)
+					)
+					lib.add(ent_flags)
+
+				if lib.has(lief.ELF.DYNAMIC_TAGS.FLAGS_1):
+					ent_flags_1 = lib.get(lief.ELF.DYNAMIC_TAGS.FLAGS_1)
+					ent_flags_1.add(lief.ELF.DYNAMIC_FLAGS_1.ORIGIN)
+				else:
+					ent_flags_1 = lief.ELF.DynamicEntryFlags(
+						lief.ELF.DYNAMIC_TAGS.FLAGS_1,
+						int(lief.ELF.DYNAMIC_FLAGS_1.ORIGIN)
+					)
+					lib.add(ent_flags_1)
+
+			# TODO: If library has rpath but no runpath, and another tool is available, only set flag
+			runpath_is_rpath = False
+			if lib.has(lief.ELF.DYNAMIC_TAGS.RUNPATH):
+				ent_runpath = lib.get(lief.ELF.DYNAMIC_TAGS.RUNPATH)
+				ent_runpath.paths = [runpath]
+			elif lib.has(lief.ELF.DYNAMIC_TAGS.RPATH):
+				# Changing the tag here causes a segfault when writing
+				ent_runpath = lib.get(lief.ELF.DYNAMIC_TAGS.RPATH)
+				ent_runpath.paths = [runpath]
+				runpath_is_rpath = True
+			else:
+				ent_runpath = lief.ELF.DynamicEntryRunPath(runpath)
+				lib.add(ent_runpath)
+
+			l.info('Writing modified elf to %s', tmp_out)
+			# for large files, warn that this might take a sec
+			if lib.virtual_size > self.lief_info.rebuild_size_warn_threshold:
+				l.info('This may take a while for large files (this one is ~%s)',
+				       logging_ex.sizeof_fmt(lib.virtual_size))
+
+			lib.write(tmp_out)
+
+			if runpath_is_rpath:
+				l.info('Re-parsing modified elf %s to patch rpath tag value', tmp_out)
+				lib = lief.parse(tmp_out)
+				sect_dyn = lib.get(lief.ELF.SECTION_TYPES.DYNAMIC)
+				ent_runpath_idx = 0
+				for ent in lib.dynamic_entries:
+					if ent.tag == lief.ELF.DYNAMIC_TAGS.RPATH:
+						ent_runpath = ent
+						break
+					ent_runpath_idx = ent_runpath_idx + 1
+				else:
+					raise RuntimeError('LIEF internal error')
+
+				sect_off = ent_runpath_idx * sect_dyn.entry_size
+				tag_off = sect_dyn.file_offset + sect_off
+
+				# assume 64-bit
+				tag_sz = 8
+				if lib.header.identity_class == lief.ELF.ELF_CLASS.CLASS32:
+					tag_sz = 4
+				# assume little endian
+				tag_end = 'little'
+				if lib.header.identity_data == lief.ELF.ELF_DATA.MSB:
+					tag_end = 'big'
+
+				tag_b = int(lief.ELF.DYNAMIC_TAGS.RUNPATH).to_bytes(tag_sz, tag_end)
+
+				with open(tmp_out, 'rb+') as tmp_out_f:
+					tmp_out_f.seek(tag_off)
+					tmp_out_f.write(tag_b)
+
+			shutil.move(tmp_out, output_path)
+			return output_path
+		finally:
+			if path.exists(tmp_out):
+				os.unlink(tmp_out)
+			op_state.lief.tool_tried = True
+
+	def _set_rpath_chrpath(
+		self,
+		bin_path: str,
+		runpath: Optional[str],
+		output_path: str,
+		inplace: bool,
+		env: Mapping[str, str],
+		op_state: RunpathOperationState
+	) -> str:
+		ilib = self.ilib
+		fname = path.basename(bin_path)
+
+		# a little insurance, helps if operating inplace
+		tmp_out_fd, tmp_out = tempfile.mkstemp(
+			suffix=self.options.sharedlib_suffixes[0],
+			prefix=fname+'.',  # noqa: E226
+			dir=self.options.cmake_tmpdir
+		)
+		os.close(tmp_out_fd)
+		if path.exists(tmp_out):
+			os.unlink(tmp_out)
+		try:
+			shutil.copyfile(bin_path, tmp_out)
+			chrpath_args = [op_state.chrpath.path, '-c', '-r', runpath, tmp_out]
+			ilib.execute_command(chrpath_args, env=env)
+
+			shutil.move(tmp_out, output_path)
+			return output_path
+		finally:
+			if path.exists(tmp_out):
+				os.unlink(tmp_out)
+			op_state.chrpath.tool_tried = True
+
+	# FIXME: runpath setting with cmake is broken on centos
+	def _set_rpath_cmake(
+		self,
+		bin_path: str,
+		runpath: Optional[str],
+		output_path: str,
+		inplace: bool,
+		env: Mapping[str, str],
+		op_state: RunpathOperationState
+	) -> str:
+		ilib = self.ilib
+		fname = path.basename(bin_path)
+
+		# a little insurance, helps if operating inplace
+		tmp_out_fd, tmp_out = tempfile.mkstemp(
+			suffix=self.options.sharedlib_suffixes[0],
+			prefix=fname + '.',
+			dir=self.options.cmake_tmpdir
+		)
+		os.close(tmp_out_fd)
+		if path.exists(tmp_out):
+			os.unlink(tmp_out)
+		try:
+			shutil.copyfile(bin_path, tmp_out)
+			cmake_args = [
+				op_state.cmake.path,
+				'-DCHRPATH_TARGETS=' + tmp_out,
+				'-DNEW_CHRPATH=' + runpath,
+				'-P', path.join(self.context.packager_dir, 'chrpath.cmake')
+			]
+			ilib.execute_command(cmake_args, env=env)
+
+			shutil.move(tmp_out, output_path)
+			return output_path
+		finally:
+			if path.exists(tmp_out):
+				os.unlink(tmp_out)
+			op_state.cmake.tool_tried = True
+
+	def _set_rpath(
+		self,
+		bin_path: str,
+		runpath: Optional[str],
+		set_origin: bool,
+		output_path: str,
+		env: Mapping[str, str]
+	) -> str:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		fname = path.basename(bin_path)
+
+		op_state = RunpathOperationState(self.tool_state)
+
+		if output_path is not None and path.isdir(output_path):
+			output_path = path.join(output_path, path.basename(bin_path))
+			# if output_path is still a directory, panic
+			if path.isdir(output_path):
+				raise OSError(errno.EISDIR, 'destination path is a directory.', output_path)
+
+		inplace = output_path is None or path.abspath(bin_path) == path.abspath(output_path)
+
+		if output_path is None:
+			output_path = bin_path
+
+		# TODO: isolate lief so that segfaults can be handled gracefully.
+		# lief tends to segfault with libc++. mark it as already tried
+		if fname.startswith('libc++.') or fname.startswith('libc++abi.'):
+			op_state.lief.tool_tried = True
+
+		done = False
+
+		l.info('%s: Setting runpath', bin_path)
+
+		# if we are setting the origin flag, we try lief first
+		if set_origin and not op_state.lief.tool_tried:
+			try:
+				ret = self._set_rpath_lief(bin_path, runpath, set_origin, output_path, inplace,
+				                           op_state)
+				done = True
+			except Exception as ex:  # noqa: B902; pylint: disable=W0703
+				op_state.lief.tool_tried = True
+				l.debug(
+					'%s: failed setting rpath with lief. %s: %s',
+					bin_path, type(ex).__name__, str(ex),
+					exc_info=True
+				)
+
+		if not done and not op_state.chrpath.tool_tried:
+			try:
+				ret = self._set_rpath_chrpath(bin_path, runpath, output_path, inplace, env,
+				                              op_state)
+				done = True
+			except Exception as ex:  # noqa: B902; pylint: disable=W0703
+				op_state.lief.tool_tried = True
+				l.debug(
+					'%s: failed setting rpath with chrpath. %s: %s',
+					bin_path, type(ex).__name__, str(ex),
+					exc_info=True
+				)
+
+		if not done and not op_state.cmake.tool_tried:
+			try:
+				ret = self._set_rpath_cmake(bin_path, runpath, output_path, inplace, env, op_state)
+				done = True
+			except Exception as ex:  # noqa: B902; pylint: disable=W0703
+				op_state.lief.tool_tried = True
+				l.debug(
+					'%s: failed setting rpath with cmake. %s: %s',
+					bin_path, type(ex).__name__, str(ex),
+					exc_info=True
+				)
+
+		if not done and not op_state.lief.tool_tried:
+			try:
+				ret = self._set_rpath_lief(bin_path, runpath, set_origin, output_path, inplace,
+				                           op_state)
+				done = True
+			except Exception as ex:  # noqa: B902; pylint: disable=W0703
+				op_state.lief.tool_tried = True
+				l.debug(
+					'%s: failed setting rpath with lief. %s: %s',
+					bin_path, type(ex).__name__, str(ex),
+					exc_info=True
+				)
+
+		if not done:
+			l.warning('%s: could not set RUNPATH', bin_path)
+			if not inplace:
+				shutil.copyfile(bin_path, output_path)
+			ret = output_path
+
+		os.chmod(ret, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |  # noqa: E222,W504
+		              stat.S_IRGRP |                stat.S_IXGRP |  # noqa: E127,E222,W504
+		              stat.S_IROTH |                stat.S_IXOTH)  # noqa: E127,E222
+
+		return ret
+
+	def set_rpath(
+		self,
+		bin_path: str,
+		runpath: Optional[str],
+		set_origin: Optional[bool] = None,
+		output_path: Optional[str] = None
+	) -> str:
+		if not self.tool_state:
+			raise OSError(errno.ENOPKG, 'Cannot set RUNPATH. lief functionality unavailable '
+			                            'and neither cmake nor chrpath could be found.')
+
+		if set_origin:
+			set_origin = self.options.set_origin_flag
+		elif set_origin is None:
+			set_origin = (
+				self.lief_info.lief_usable and  # noqa: W504
+				self.options.set_origin_flag and  # noqa: W504
+				('$ORIGIN' in runpath or '${ORIGIN}' in runpath)
+			)
+
+		env = self.fill_out_envdict()
+		env['LANG'] = 'C'
+
+		return self._set_rpath(bin_path, runpath, set_origin, output_path, env)
+
+	@overload
+	def set_rpath_dispatch(
+		self,
+		bin_paths: Iterable[str],
+		runpath: Optional[str],
+		set_origin: Optional[bool] = None
+	) -> MutableSequence[Future]:
+		pass
+
+	@overload
+	def set_rpath_dispatch(
+		self,
+		bin_paths: Iterable[Tuple[str, str]],
+		runpath: Optional[str],
+		set_origin: Optional[bool] = None
+	) -> MutableSequence[Future]:
+		pass
+
+	def set_rpath_dispatch(
+		self,
+		bin_paths: Union[Iterable[str], Iterable[Tuple[str, str]]],
+		runpath: Optional[str],
+		set_origin: Optional[bool] = None
+	) -> MutableSequence[Future]:
+		results = []
+
+		if not self.tool_state:
+			raise OSError(errno.ENOPKG, 'Cannot set RUNPATH. lief functionality unavailable '
+			                            'and neither cmake nor chrpath could be found.')
+
+		try:
+			tup_len = len(next(iter(bin_paths)))
+		except StopIteration:
+			return results
+
+		if set_origin:
+			set_origin = self.options.set_origin_flag
+		elif set_origin is None:
+			set_origin = (
+				self.lief_info.lief_usable and  # noqa: W504
+				self.options.set_origin_flag and  # noqa: W504
+				('$ORIGIN' in runpath or '${ORIGIN}' in runpath)
+			)
+
+		env = self.fill_out_envdict()
+		env['LANG'] = 'C'
+
+		if tup_len != 2:
+			bin_paths = zip(bin_paths, itertools.repeat(None))  # pylint: disable=W1637
+
+		for bin_path, output_path in bin_paths:
+			results.append(
+				self.executor.submit(
+					self._set_rpath,
+					bin_path,
+					runpath,
+					set_origin,
+					output_path,
+					env
+				)
+			)
+
+		return results
+
+
+def _main() -> int:
+	l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+	options = RunpathUtilOptions()
+	options.parse_args()
+
+	augment_module_search_paths(options=options)
+
+	context = PackagerContext[RunpathUtilOptions](options)
+	context.init_logging(options.verbosity)
+	logging_ex.setup_stacktrace_signal()
+
+	output_path_is_dir = options.output_path is not None and path.isdir(options.output_path)
+
+	if len(options.libraries) > 1 and options.output_path is not None and not output_path_is_dir:
+		l.error('Multiple libraries passed in, but output path %s is not a directory',
+		        options.output_path)
+		return errno.ENOTDIR
+
+	context.lief_info.check_and_whine()
+	if not context.lief_info.lief_usable:
+		l.warning('lief functionality not available, cannot set DF_ORIGIN flag.')
+
+	runpath_util = RunpathUtil(context)
+
+	for libpath in options.libraries:
+		# We don't want to re-evaluate whether output_path is a dir every time, in case it
+		# is deleted midway through. We evaluate once, and pre-evaluate full destinations
+		# to avoid this potential race condition
+		output_path = options.output_path
+		if output_path_is_dir:
+			output_path = path.join(output_path, path.basename(libpath))
+			# if output_path is still a directory, panic
+			if path.isdir(output_path):
+				l.error('destination path %s is a directory.', output_path)
+				return errno.EISDIR
+
+		runpath_util.set_rpath(libpath, options.runpath, output_path=output_path)
+
+	return 0
+
+
+if __name__ == '__main__':
+	sys.exit(_main())

--- a/packaging/userspace/script_common.py
+++ b/packaging/userspace/script_common.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import os  # noqa: I100,I202
+import itertools
+from concurrent.futures import Future
+from concurrent.futures import FIRST_EXCEPTION as F_FIRST_EXCEPTION
+from concurrent.futures import wait as f_wait
+from typing import Any, Optional, TypeVar, overload
+
+from compat_shims import Callable, Collection, Iterable, Iterator, MutableMapping, MutableSequence
+from compat_shims import Sequence
+
+__all__ = [
+	'irods_scripts_dir',
+	'futures_wait',
+	'IteratorFactory',
+	'CollectionCompoundView',
+	'FrozenList'
+]
+
+T_co = TypeVar('T_co', covariant=True)  # pylint: disable=C0103
+
+irods_scripts_dir = '/var/lib/irods/scripts'  # pylint: disable=C0103
+if 'IRODS_SCRIPTS_DIR' in os.environ:
+	irods_scripts_dir = os.environ['IRODS_SCRIPTS_DIR']
+
+
+def futures_wait(futures: Iterable[Future]) -> MutableSequence:
+	fs_done, fs_notdone = f_wait(futures, return_when=F_FIRST_EXCEPTION)  # pylint: disable=W0612
+	res = [f.result() for f in fs_done]
+	return res
+
+
+class IteratorFactory(Iterable[T_co]):
+
+	def __init__(self, fn: Callable, *args: Any, **kwargs: Any):
+		self.fn: Callable = fn
+		self.args: MutableSequence[Any] = args
+		self.kwargs: MutableMapping[str, Any] = kwargs
+
+	def __iter__(self) -> Iterator[T_co]:
+		return self.fn(*self.args, **self.kwargs)
+
+
+class CollectionCompoundView(Collection[T_co]):
+
+	def __init__(self, collections: Iterable[Collection[T_co]]):
+		super().__init__()
+		self._collections = collections
+
+	@property
+	def collections(self) -> Iterable[Collection[T_co]]:
+		return self._collections
+
+	def __contains__(self, obj: T_co) -> bool:
+		return any(obj in coll for coll in self.collections)
+
+	def __len__(self) -> int:
+		sz = 0
+		for coll in self.collections:
+			sz = sz + len(coll)
+		return sz
+
+	def __iter__(self) -> Iterator[T_co]:
+		return itertools.chain.from_iterable(self.collections)
+
+
+class FrozenList(Sequence[T_co]):
+
+	@overload
+	def __init__(self):  # noqa: ANN204
+		pass
+
+	@overload
+	def __init__(self, iterable: Iterable[T_co]):
+		pass
+
+	def __init__(self, *args: Iterable[T_co]):
+		super().__init__()
+		if len(args) > 1:
+			raise ValueError('Too many positional arguments')
+		elif len(args) == 1 and args[0] is not None:
+			self._list = list(args[0])
+		else:
+			self._list = []
+
+	def __add__(self, other: Sequence[T_co]) -> Sequence[T_co]:
+		if isinstance(other, FrozenList):
+			return FrozenList(self._list + other._list)  # pylint: disable=W0212
+		return FrozenList(self._list + other)
+
+	def __contains__(self, value: T_co) -> bool:
+		return value in self._list
+
+	def __eq__(self, other: Sequence[T_co]) -> bool:
+		if self is other:
+			return True
+		if isinstance(other, MutableSequence):
+			return False
+		if isinstance(other, FrozenList):
+			return self._list == other._list  # pylint: disable=W0212
+		if isinstance(other, Sequence):
+			return tuple(self._list) == tuple(other)
+
+		return False
+
+	def __format__(self, format_spec: str) -> str:
+		return self._list.__format__(format_spec)
+
+	def __getitem__(self, index: int) -> T_co:
+		return self._list[index]
+
+	def __iter__(self) -> Iterator[T_co]:
+		return iter(self._list)
+
+	def __len__(self) -> int:
+		return len(self._list)
+
+	def __repr__(self) -> str:
+		return self._list.__repr__()
+
+	def __reversed__(self) -> Iterator[T_co]:
+		return reversed(self._list)
+
+	def __str__(self) -> str:
+		return self._list.__str__()
+
+	def copy(self) -> Sequence[T_co]:
+		return FrozenList(self._list.copy())
+
+	def count(self, value: T_co) -> int:
+		return self._list.count(value)
+
+	def index(self, value: T_co, start: int = 0, stop: Optional[int] = None) -> int:
+		if stop is None:
+			return self._list.index(value, start)
+		else:
+			return self._list.index(value, start, stop)

--- a/packaging/userspace/strip_util.py
+++ b/packaging/userspace/strip_util.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import shutil, sys, os, stat  # pylint: disable=C0410
+import argparse  # noqa: I100
+import errno
+import logging
+import tempfile
+from concurrent.futures import Executor, Future
+from os import path
+from typing import Generic, Optional, Union, overload
+
+import log_instrumentation as logging_ex
+from compat_shims import Iterable, Mapping, MutableSequence, Tuple
+from context import PackagerContext, PackagerOptionsBase, augment_module_search_paths
+from options import RunArgOption
+from utilbase import PackagerToolState, PackagerUtilBase, ToolStateT
+from elfinfo_util import ElfInfoUtil, ElfInfoUtilOptionsBase
+
+__all__ = [
+	'StripUtil',
+	'StripToolStateBase',
+	'StripToolState',
+	'StripUtilOptionsBase'
+]
+
+
+class StripUtilOptionsBase(ElfInfoUtilOptionsBase):  # pylint: disable=W0223
+	strip_path: Optional[str] = RunArgOption(
+		'--strip-path', metavar='TOOLPATH',
+		group=PackagerOptionsBase.tool_args,
+		action='store', opt_type=str, default=None,
+		help='Path to strip tool to use'
+	)
+
+	preserve_libs: bool = RunArgOption(
+		'--preserve-unneeded-librefs',
+		action='store_true', default=False,
+		help='Do not remove DT_NEEDED entries for unneeded libraries'
+	)
+
+
+class StripUtilOptions(StripUtilOptionsBase):
+	output_path: Optional[str] = RunArgOption(
+		'-o', '--output', metavar='PATH',
+		action='store', default=None,
+		help='Place stripped output into PATH'
+	)
+
+	libraries: MutableSequence[str] = RunArgOption(
+		metavar='FILE', nargs='+',
+		action='store', opt_type=str, default=None,
+		help='ELF binaries to strip'
+	)
+
+	def create_empty_argparser(self) -> argparse.ArgumentParser:
+		return argparse.ArgumentParser(
+			description='Strip unneeded symbols and library imports',
+			allow_abbrev=False
+		)
+
+
+class StripToolStateBase(Generic[ToolStateT]):
+
+	def __init__(
+		self,
+		lief_tool: ToolStateT,
+		strip_tool: ToolStateT
+	):
+		self._lief_tool = lief_tool
+		self._strip_tool = strip_tool
+
+	@property
+	def lief_tool(self) -> ToolStateT:
+		return self._lief_tool
+
+	@property
+	def lief(self) -> ToolStateT:
+		return self.lief_tool
+
+	@property
+	def strip_tool(self) -> ToolStateT:
+		return self._strip_tool
+
+	@property
+	def strip(self) -> ToolStateT:
+		return self.strip_tool
+
+	def __bool__(self) -> bool:
+		return bool(self.strip_tool)
+
+
+class StripToolState(StripToolStateBase[PackagerToolState]):
+	pass
+
+
+class StripUtil(PackagerUtilBase[StripUtilOptionsBase]):
+
+	def __init__(
+		self,
+		context: PackagerContext[StripUtilOptionsBase],
+		elfinfo_util: ElfInfoUtil,
+		executor: Optional[Executor] = None,
+		raise_if_strip_not_found: bool = False
+	):
+		super().__init__(context, executor)
+		self.libinfo_util: ElfInfoUtil = elfinfo_util
+
+		env = self.fill_out_envdict()
+		strip_path = self.find_tool(
+			['llvm-strip', 'strip'],
+			self.options.strip_path,
+			raise_if_not_found=raise_if_strip_not_found,
+			prettyname='strip',
+			env=env
+		)
+
+		self._tool_state = StripToolState(
+			PackagerToolState(is_usable=self.lief_info.lief_usable),
+			PackagerToolState(is_usable=bool(strip_path), path=strip_path)
+		)
+
+	@property
+	def tool_state(self) -> StripToolState:
+		return self._tool_state
+
+	def _strip(
+		self,
+		bin_path: str,
+		strip_debug_symbols: bool,
+		output_path: str,
+		inplace: bool,
+		env: Mapping[str, str]
+	) -> str:
+		ilib = self.ilib
+		fname = path.basename(bin_path)
+
+		# a little insurance, helps if operating inplace
+		tmp_out_fd, tmp_out = tempfile.mkstemp(
+			suffix=self.options.sharedlib_suffixes[0],
+			prefix=fname + '.',
+			dir=self.options.cmake_tmpdir
+		)
+		os.close(tmp_out_fd)
+		if path.exists(tmp_out):
+			os.unlink(tmp_out)
+		try:  # pylint: disable=W0717
+			strip_args = [self.tool_state.strip.path, '--strip-unneeded']
+			if strip_debug_symbols:
+				strip_args.append('--strip-debug')
+			strip_args.append(bin_path)
+			if not inplace:
+				strip_args.extend(['-o', tmp_out])
+
+			ilib.execute_command(strip_args, env=env)
+
+			shutil.move(tmp_out, output_path)
+		finally:
+			if path.exists(tmp_out):
+				os.unlink(tmp_out)
+
+		os.chmod(output_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |  # noqa: E222,W504
+		                      stat.S_IRGRP |                stat.S_IXGRP |  # noqa: E127,E222,W504
+		                      stat.S_IROTH |                stat.S_IXOTH)  # noqa: E127,E222
+
+		return output_path
+
+	def strip(
+		self,
+		bin_path: str,
+		strip_debug_symbols: bool = False,
+		output_path: Optional[str] = None
+	) -> str:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		if not self.tool_state:
+			raise OSError(errno.ENOENT, 'Cannot strip binary. strip tool not found.')
+
+		if output_path is not None and path.isdir(output_path):
+			output_path = path.join(output_path, path.basename(bin_path))
+			# if output_path is still a directory, panic
+			if path.isdir(output_path):
+				raise OSError(errno.EISDIR, 'destination path is a directory.', output_path)
+
+		inplace = output_path is None or path.abspath(bin_path) == path.abspath(output_path)
+
+		if output_path is None:
+			output_path = bin_path
+
+		l.info('%s: Stripping unneeded symbols', output_path)
+
+		env = self.fill_out_envdict()
+
+		return self._strip(bin_path, strip_debug_symbols, output_path, inplace, env)
+
+	def _clean_unused_dependencies(
+		self,
+		bin_path: str,
+		output_path: str,
+		inplace: bool
+	) -> str:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		fname = path.basename(bin_path)
+		lief = self.lief
+
+		# lief tends to segfault with libc++
+		if fname.startswith('libc++.') or fname.startswith('libc++abi.'):
+			unneeded_libs = []
+		else:
+			unneeded_libs = self.libinfo_util.get_unused_dependencies(bin_path)
+		if len(unneeded_libs) > 0:
+			_raw_uneeded_libs = list(unneeded_libs)
+			unneeded_libs = set(unneeded_libs)  # pylint: disable=R0204
+
+			# FIXME: Figure out why we have to do this
+			for unneeded_lib in _raw_uneeded_libs:
+				if unneeded_lib.startswith('libirods_'):
+					unneeded_libs.remove(unneeded_lib)
+
+		if len(unneeded_libs) > 0:
+			lib = lief.parse(bin_path)
+
+			# TODO: Figure out how to clean these out
+			# TODO: Get these from elfinfo util
+			versioned_libs = {symver.name for symver in lib.symbols_version_requirement}
+			if l.isEnabledFor(logging.DEBUG):
+				versioned_libs.intersection_update(unneeded_libs)
+				if len(versioned_libs) > 0:
+					l.debug(
+						'%s: DT_VERNEED subentries found for unused %s, '
+						'skipping removal of DT_NEEDED entry(s).',
+						output_path, ', '.join(versioned_libs)
+					)
+			unneeded_libs.difference_update(versioned_libs)
+
+		if len(unneeded_libs) > 0:
+			if l.isEnabledFor(logging.INFO):
+				l.info(
+					'%s: removing DT_NEEDED entry(s) for %s.',
+					output_path, ', '.join(unneeded_libs)
+				)
+			for unneeded_lib in unneeded_libs:
+				if lib.has_library(unneeded_lib):
+					lib.remove_library(unneeded_lib)
+				else:
+					l.warning(
+						'%s: ldd reports %s as unneeded import, but %s not found in imports.',
+						output_path, unneeded_lib, unneeded_lib
+					)
+
+			# a little insurance, helps if operating inplace
+			tmp_out_fd, tmp_out = tempfile.mkstemp(
+				suffix=self.options.sharedlib_suffixes[0],
+				prefix=fname + '.',
+				dir=self.options.cmake_tmpdir
+			)
+			os.close(tmp_out_fd)
+			if path.exists(tmp_out):
+				os.unlink(tmp_out)
+			try:
+				l.info('Writing cleaned elf to %s', tmp_out)
+				# for large files, warn that this might take a sec
+				if lib.virtual_size > self.lief_info.rebuild_size_warn_threshold and l.isEnabledFor(logging.INFO):
+					l.info(
+						'This may take a while for large files (this one is ~%s)',
+						logging_ex.sizeof_fmt(lib.virtual_size)
+					)
+
+				lib.write(tmp_out)
+				shutil.move(tmp_out, output_path)
+			finally:
+				if path.exists(tmp_out):
+					os.unlink(tmp_out)
+
+		elif not inplace:
+			shutil.copyfile(bin_path, output_path)
+
+		os.chmod(output_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |  # noqa: E222,W504
+		                      stat.S_IRGRP |                stat.S_IXGRP |  # noqa: E127,E222,W504
+		                      stat.S_IROTH |                stat.S_IXOTH)  # noqa: E127,E222
+
+		return output_path
+
+	def clean_unused_dependencies(
+		self,
+		bin_path: str,
+		output_path: Optional[str] = None
+	) -> str:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		if not self.lief_info.lief_usable:
+			raise OSError(errno.ENOPKG, 'lief functionality unavailable')
+
+		if output_path is not None and path.isdir(output_path):
+			output_path = path.join(output_path, path.basename(bin_path))
+			# if output_path is still a directory, panic
+			if path.isdir(output_path):
+				raise OSError(errno.EISDIR, 'destination path is a directory.', output_path)
+
+		inplace = output_path is None or path.abspath(bin_path) == path.abspath(output_path)
+
+		if output_path is None:
+			output_path = bin_path
+
+		l.info('%s: Cleaning up unneeded library imports', output_path)
+
+		return self._clean_unused_dependencies(bin_path, output_path, inplace)
+
+	def strip_and_clean(
+		self,
+		bin_path: str,
+		strip_debug_symbols: bool = False,
+		intermediate_path: Optional[str] = None,
+		output_path: Optional[str] = None
+	) -> str:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		if not self.tool_state:
+			raise OSError(errno.ENOENT, 'Cannot strip binary. strip tool not found.')
+
+		if intermediate_path is not None and path.isdir(intermediate_path):
+			intermediate_path = path.join(intermediate_path, path.basename(bin_path))
+			# if intermediate_path is still a directory, panic
+			if path.isdir(intermediate_path):
+				raise OSError(errno.EISDIR, 'destination path is a directory.', intermediate_path)
+
+		if output_path is not None and path.isdir(output_path):
+			output_path = path.join(output_path, path.basename(bin_path))
+			# if output_path is still a directory, panic
+			if path.isdir(output_path):
+				raise OSError(errno.EISDIR, 'destination path is a directory.', output_path)
+
+		if intermediate_path is None and output_path is None:
+			inplace_1 = True
+			intermediate_path = bin_path
+			output_path = bin_path
+		elif output_path and not intermediate_path:
+			intermediate_path = output_path
+			inplace_1 = path.abspath(bin_path) == path.abspath(output_path)
+		elif intermediate_path and not output_path:
+			output_path = bin_path
+			inplace_1 = path.abspath(bin_path) == path.abspath(intermediate_path)
+		else:
+			inplace_1 = path.abspath(bin_path) == path.abspath(intermediate_path)
+
+		env = self.fill_out_envdict()
+
+		l.info('%s: Stripping unneeded symbols', output_path)
+
+		intermediate_path = self._strip(
+			bin_path,
+			strip_debug_symbols,
+			intermediate_path,
+			inplace_1,
+			env
+		)
+
+		inplace_2 = path.abspath(intermediate_path) == path.abspath(output_path)
+
+		if self.tool_state.lief.is_usable:
+			l.info('%s: Cleaning up unneeded library imports', output_path)
+			return self._clean_unused_dependencies(
+				intermediate_path,
+				output_path,
+				inplace_2
+			)
+		else:
+			if not inplace_2:
+				shutil.copyfile(intermediate_path, output_path)
+			return output_path
+
+	@overload
+	def strip_and_clean_dispatch(
+		self,
+		bin_paths: Iterable[str],
+		strip_debug_symbols: bool = False
+	) -> MutableSequence[Future]:
+		pass
+
+	@overload
+	def strip_and_clean_dispatch(
+		self,
+		bin_paths: Iterable[Tuple[str, str]],
+		strip_debug_symbols: bool = False
+	) -> MutableSequence[Future]:
+		pass
+
+	@overload
+	def strip_and_clean_dispatch(
+		self,
+		bin_paths: Iterable[Tuple[str, str, str]],
+		strip_debug_symbols: bool = False
+	) -> MutableSequence[Future]:
+		pass
+
+	def strip_and_clean_dispatch(
+		self,
+		bin_paths: Union[Iterable[str], Iterable[Tuple[str, str]], Iterable[Tuple[str, str, str]]],
+		strip_debug_symbols: bool = False
+	) -> MutableSequence[Future]:
+		results = []
+		try:
+			tup_len = len(next(iter(bin_paths)))
+		except StopIteration:
+			return results
+
+		if tup_len == 2:
+			for bin_path, output_path in bin_paths:
+				results.append(
+					self.executor.submit(
+						self.strip_and_clean,
+						bin_path,
+						strip_debug_symbols=strip_debug_symbols,
+						output_path=output_path
+					)
+				)
+		elif tup_len == 3:
+			for bin_path, intermediate_path, output_path in bin_paths:
+				results.append(
+					self.executor.submit(
+						self.strip_and_clean,
+						bin_path,
+						strip_debug_symbols=strip_debug_symbols,
+						intermediate_path=intermediate_path,
+						output_path=output_path
+					)
+				)
+		else:
+			for bin_path in bin_paths:
+				results.append(
+					self.executor.submit(
+						self.strip_and_clean,
+						bin_path,
+						strip_debug_symbols=strip_debug_symbols
+					)
+				)
+
+		return results
+
+
+def _main() -> int:
+	l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+	options = StripUtilOptions()
+	options.parse_args()
+
+	augment_module_search_paths(options=options)
+
+	context = PackagerContext[StripUtilOptions](options)
+	context.init_logging(options.verbosity)
+	logging_ex.setup_stacktrace_signal()
+
+	output_path_is_dir = options.output_path is not None and path.isdir(options.output_path)
+
+	if len(options.libraries) > 1 and options.output_path is not None and not output_path_is_dir:
+		l.error('Multiple libraries passed in, but output path %s is not a directory',
+		        options.output_path)
+		return errno.ENOTDIR
+
+	context.lief_info.check_and_whine()
+	if not context.lief_info.lief_usable:
+		l.warning('lief functionality not available, skipping removal of unneeded library imports.')
+
+	libinfo_util = ElfInfoUtil(context)
+	strip_util = StripUtil(context, libinfo_util, raise_if_strip_not_found=True)
+
+	for libpath in options.libraries:
+		# We don't want to re-evaluate whether output_path is a dir every time, in case it
+		# is deleted midway through. We evaluate once, and pre-evaluate full destinations
+		# to avoid this potential race condition
+		output_path = options.output_path
+		if output_path_is_dir:
+			output_path = path.join(output_path, path.basename(libpath))
+			# if output_path is still a directory, panic
+			if path.isdir(output_path):
+				l.error('destination path %s is a directory.', output_path)
+				return errno.EISDIR
+
+		strip_util.strip_and_clean(libpath, output_path=output_path)
+
+	return 0
+
+
+if __name__ == '__main__':
+	sys.exit(_main())

--- a/packaging/userspace/tar_util.py
+++ b/packaging/userspace/tar_util.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import os  # noqa: I100,I202
+import logging  # noqa: I100
+from enum import Enum
+from typing import Optional
+
+from compat_shims import NoReturn
+from context import PackagerContext, PackagerOptionsBase
+from options import RunArgOption
+from utilbase import PackagerUtilBase
+
+__all__ = ['TarUtil', 'TarUtilOptionsBase', 'TarToolFlavor']
+
+
+class TarUtilOptionsBase(PackagerOptionsBase):  # pylint: disable=W0223
+	tar_path: Optional[str] = RunArgOption(
+		'--tar-path', metavar='TOOLPATH',
+		group=PackagerOptionsBase.tool_args,
+		action='store', opt_type=str, default=None,
+		help='Path to tar tool to use'
+	)
+
+
+class TarToolFlavor(Enum):
+	BSD = 1
+	GNU = 2
+
+
+class TarUtil(PackagerUtilBase[TarUtilOptionsBase]):
+
+	def __init__(
+		self,
+		context: PackagerContext[TarUtilOptionsBase],
+		raise_if_tool_flavor_unrecognized: bool = True
+	):
+		super().__init__(context, None)
+		ilib = self.ilib
+
+		env = self.fill_out_envdict()
+		env['LANG'] = 'C'
+
+		self.tar_path: str = self.find_tool(
+			['bsdtar', 'tar'],
+			self.options.tar_path,
+			prettyname='tar',
+			env=env
+		)
+
+		# figure out tool flavor
+		tar_flavor = None
+		tar_ver_out, tar_ver_err = ilib.execute_command(  # pylint: disable=W0612
+			[self.tar_path, '--version'],
+			env=env
+		)
+		tar_ver_out = tar_ver_out.partition('\n')[0]
+		if 'bsdtar' in tar_ver_out:
+			tar_flavor = TarToolFlavor.BSD
+		elif 'GNU tar' in tar_ver_out:
+			tar_flavor = TarToolFlavor.GNU
+		elif raise_if_tool_flavor_unrecognized:
+			raise OSError(
+				errno.ENOPKG,
+				'tar tool incompatible (only GNU tar and bsdtar are supported)'
+			)
+
+		self.tar_flavor: Optional[TarToolFlavor] = tar_flavor
+
+	def create_tarball(
+		self,
+		source_dir: str,
+		output_path: str
+	) -> NoReturn:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		ilib = self.ilib
+
+		l.info('Packing: %s', output_path)
+
+		env = self.fill_out_envdict()
+		env['LANG'] = 'C'
+
+		tar_args = [self.tar_path, '-c', '-a', '-f', output_path]
+
+		if self.tar_flavor == TarToolFlavor.BSD:
+			tar_args.append('--no-fflags')
+			# bsdtar will derive format from filename
+			tar_args.extend(['--numeric-owner', '--uid', '0', '--gid', '0'])
+		elif self.tar_flavor == TarToolFlavor.GNU:
+			# GNU tar has no equivalent for --no-fflags
+			tar_args.extend(['-H', 'posix'])
+			tar_args.extend(['--numeric-owner', '--owner=0', '--group=0'])
+
+		tar_args.extend(['-C', source_dir])
+		tar_args.extend(os.listdir(source_dir))
+
+		ilib.execute_command(tar_args, env=env)

--- a/packaging/userspace/userspace-packager.py
+++ b/packaging/userspace/userspace-packager.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import shutil, sys, os, stat  # pylint: disable=C0410
+import argparse
+import concurrent.futures
+import errno
+import itertools
+import logging
+from concurrent.futures import Executor
+from os import path
+from typing import Optional
+
+import script_common
+import log_instrumentation as logging_ext
+from compat_shims import Iterable, NoReturn, Sequence, Set, linux_distribution
+from context import PackagerContext, PackagerOptionsBase, augment_module_search_paths
+from options import RunArgOption
+from utilbase import PackagerUtilBase
+from elfinfo_util import ElfInfoUtil
+from libdirectives import LibDirectiveOptionsBase, LibDirectives, LibFsInfo
+from strip_util import StripUtil, StripUtilOptionsBase
+from runpath_util import RunpathUtil, RunpathUtilOptionsBase
+from tar_util import TarUtil, TarUtilOptionsBase
+
+
+class PackagerOptions(StripUtilOptionsBase, LibDirectiveOptionsBase, RunpathUtilOptionsBase, TarUtilOptionsBase):
+	output_path: Optional[str] = RunArgOption(
+		'-o', '--output', metavar='PATH',
+		action='store', default=None,
+		help='Create tarball at PATH'
+	)
+
+	cmake_install_prefix: str = RunArgOption(
+		'--cmake-install-prefix', metavar='PATH',
+		group=PackagerOptionsBase.gnuinstalldirs_args,
+		action='store', opt_type=str, default='/usr',
+		help='CMAKE_INSTALL_PREFIX'
+	)
+	install_bindir: str = RunArgOption(
+		'--cmake-install-bindir', metavar='PATH',
+		group=PackagerOptionsBase.gnuinstalldirs_args,
+		action='store', opt_type=str, default='bin',
+		help='CMAKE_INSTALL_BINDIR'
+	)
+	install_sbindir: str = RunArgOption(
+		'--cmake-install-sbindir', metavar='PATH',
+		group=PackagerOptionsBase.gnuinstalldirs_args,
+		action='store', opt_type=str, default='sbin',
+		help='CMAKE_INSTALL_SBINDIR'
+	)
+	install_libdir: str = RunArgOption(
+		'--cmake-install-libdir', metavar='PATH',
+		group=PackagerOptionsBase.gnuinstalldirs_args,
+		action='store', opt_type=str, default='lib',
+		help='CMAKE_INSTALL_LIBDIR'
+	)
+
+	irods_bindir: str = RunArgOption(
+		'--irods-install-bindir', metavar='PATH',
+		group=PackagerOptionsBase.ipath_args,
+		action='store', opt_type=str, default='bin'
+	)
+	irods_sbindir: str = RunArgOption(
+		'--irods-install-sbindir', metavar='PATH',
+		group=PackagerOptionsBase.ipath_args,
+		action='store', opt_type=str, default='sbin'
+	)
+	irods_libdir: str = RunArgOption(
+		'--irods-install-libdir', metavar='PATH',
+		group=PackagerOptionsBase.ipath_args,
+		action='store', opt_type=str, default='lib'
+	)
+	irods_plugsdir: str = RunArgOption(
+		'--irods-pluginsdir', metavar='PATH',
+		group=PackagerOptionsBase.ipath_args,
+		action='store', opt_type=str, default='lib/irods/plugins'
+	)
+
+	irods_runtime_libs: Sequence[str] = RunArgOption(
+		'--irods-runtime-lib', metavar='FILE',
+		action='append', opt_type=str, default=[]
+	)
+	libcxx_libpaths: Sequence[str] = RunArgOption(
+		'--libcxx-libpath', metavar='FILE',
+		action='append', opt_type=str, default=[]
+	)
+
+	build_dir: str = RunArgOption(
+		'--build-dir', metavar='PATH',
+		action='store', opt_type=str, default=os.getcwd()
+	)
+	work_dir: Optional[str] = RunArgOption(
+		'--work-dir', metavar='PATH',
+		action='store', opt_type=str, default=None
+	)
+
+	tarball_root_dir_name: Optional[str] = RunArgOption(
+		'--tarball-root-dir-name', metavar='DIRNAME',
+		action='store', opt_type=str, default=None
+	)
+
+	install_components: Sequence[str] = RunArgOption(
+		'--install-component', metavar='COMPONENT',
+		action='append', opt_type=str, default=[]
+	)
+	script_icommands: Sequence[str] = RunArgOption(
+		'--script-icommand', metavar='NAME',
+		action='append', opt_type=str, default=[]
+	)
+
+	def create_empty_argparser(self) -> argparse.ArgumentParser:
+		return argparse.ArgumentParser(
+			description='Package icommands userspace tarball',
+			allow_abbrev=False
+		)
+
+
+class Packager(PackagerUtilBase[PackagerOptions]):
+
+	def __init__(
+		self,
+		context: PackagerContext[PackagerOptions],
+		executor: Optional[Executor] = None,
+	):
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		super().__init__(context, executor)
+
+		if not self.options.target_platform:
+			distro = linux_distribution(full_distribution_name=False)
+			self.options.target_platform = distro[0].lower()
+			self.options.target_platform_variant = distro[1].partition('.')[0].lower()
+		if self.options.target_platform_variant == 'none' or self.options.target_platform_variant == 'rolling':
+			self.options.target_platform_variant = None
+
+		if self.options.set_origin_flag is None and (
+			self.options.target_platform == 'centos' and self.options.target_platform_variant == '7'
+		):
+			self.options.set_origin_flag = False
+
+		context.lief_info.check_and_whine()
+		self.elfinfo_util = ElfInfoUtil(context, executor=executor, raise_if_ldd_not_found=True)
+		self.strip_util = StripUtil(context, self.elfinfo_util, executor=executor)
+		self.runpath_util = RunpathUtil(context, executor=executor)
+		self.tar_util = TarUtil(context)
+
+		if not self.runpath_util.tool_state.cmake:
+			raise OSError(errno.ENOENT, 'Could not find cmake tool')
+
+		if not context.lief_info.lief_usable:
+			l.warning(
+				'lief functionality not available. Will not be able to remove DT_NEEDED '
+				'entries for unneeded libraries, set DF_ORIGIN flags, or set RUNPATH in binaries '
+				'without pre-existing values. This can result in additional libraries being '
+				'included in the package, and may also result in LD_LIBRARY_PATH needing to be '
+				'set to run programs from the package.'
+			)
+			if not self.runpath_util.tool_state:
+				l.error(
+					'Niehter chrpath nor cmake could be found. Without lief, cmake, or chrpath, '
+					'runpath will not be set in package binaries. This will result in bad '
+					'runpath/rpath values and LD_LIBRARY_PATH needing to be set to run programs '
+					'from the package.'
+				)
+
+		self.lib_directives = LibDirectives(context)
+
+		self.work_dir = self.options.work_dir
+		self.pkg_dir = path.join(self.work_dir, 'pkg')
+		if self.options.tarball_root_dir_name:
+			self.pkg_dir_root = path.join(self.pkg_dir, self.options.tarball_root_dir_name)
+		else:
+			self.pkg_dir_root = self.pkg_dir
+
+		if path.isabs(self.options.install_bindir):
+			self.pkg_bin_dir = path.join(self.pkg_dir_root, 'bin')
+		else:
+			self.pkg_bin_dir = path.join(self.pkg_dir_root, self.options.install_bindir)
+		if path.isabs(self.options.irods_libdir):
+			l.warning(
+				'irods-install-libdir is an absolute path. '
+				'If iRODS was built with CMAKE_INSTALL_LIBDIR or IRODS_PLUGINS_DIRECTORY '
+				'set to an absolute path, userspace packages will likely not function.'
+			)
+			self.pkg_lib_dir = path.join(self.pkg_dir_root, 'lib')
+		else:
+			self.pkg_lib_dir = path.join(self.pkg_dir_root, self.options.irods_libdir)
+		if path.isabs(self.options.irods_plugsdir):
+			l.warning(
+				'irods-pluginsdir is an absolute path. '
+				'If iRODS was built with CMAKE_INSTALL_LIBDIR or IRODS_PLUGINS_DIRECTORY '
+				'set to an absolute path, userspace packages will likely not function.'
+			)
+			self.pkg_plugs_dir = path.join(self.pkg_lib_dir, 'irods/plugins')
+		else:
+			self.pkg_plugs_dir = path.join(self.pkg_dir_root, self.options.irods_plugsdir)
+
+		self.icommand_binaries = {}
+		self.icommand_scripts = {}
+
+		self.irods_runtime_libs = {}
+		self.irods_runtime_plugs = set()
+
+		# all libs go in here as soon as they've been prepared
+		# soname : path
+		self.prepared_libs = {}
+
+		# mapping of soname to path for all external libraries we depend on (pre-strip)
+		self.ext_lib_paths = {}
+
+		# virtual libs (vdso), ld itself, etc.
+		self.ldd_other_libs = set()
+
+		# libraries encountered during dependency resolution that do not have a directive
+		self.untracked_libs = {}
+
+	def prepare_workspace(self) -> NoReturn:
+		if not path.exists(self.options.cmake_tmpdir):
+			os.mkdir(self.options.cmake_tmpdir)
+		if path.exists(self.work_dir):
+			shutil.rmtree(self.work_dir)
+		os.mkdir(self.work_dir)
+		os.makedirs(self.pkg_dir_root)
+		os.makedirs(self.pkg_bin_dir)
+		os.makedirs(self.pkg_lib_dir)
+		os.makedirs(self.pkg_plugs_dir)
+
+	def prepare_icommands(self) -> NoReturn:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+		ilib = self.ilib
+
+		self.context.status(l, '-- Gathering iCommands.')
+
+		cmake_pfx = path.join(self.options.work_dir, 'cmake_pfx')
+
+		if path.exists(cmake_pfx):
+			shutil.rmtree(cmake_pfx)
+		os.mkdir(cmake_pfx)
+
+		cmake_env = self.fill_out_envdict(self.context.envdict)
+		cmake_env.pop('DESTDIR', '')
+
+		for install_component in self.options.install_components:
+			# cmake --install not introduced until CMake 3.15
+			cmake_args = [
+				self.runpath_util.tool_state.cmake.path,
+				'-DCMAKE_INSTALL_PREFIX=' + cmake_pfx,
+				'-DCMAKE_INSTALL_COMPONENT=' + install_component,
+				'-P', path.join(self.options.build_dir, 'cmake_install.cmake')
+			]
+			ilib.execute_command(cmake_args, env=cmake_env)
+
+		# for now, assume everything we want is in $/bin
+		dest_bin = self.pkg_bin_dir
+
+		if path.isabs(self.options.install_bindir):
+			cmake_pfx_bin = path.join(cmake_pfx, self.options.install_bindir[1:])
+		#elif path.isabs(self.options.cmake_install_prefix):
+		#	cmake_pfx_bin = path.join(cmake_pfx, self.options.cmake_install_prefix[1:], self.options.install_bindir)
+		#else:
+		#	cmake_pfx_bin = path.join(cmake_pfx, self.options.cmake_install_prefix, self.options.install_bindir)
+		else:
+			cmake_pfx_bin = path.join(cmake_pfx, self.options.install_bindir)
+
+		icommand_names = list(os.listdir(cmake_pfx_bin))
+
+		for icommand_script in self.options.script_icommands:
+			if icommand_script in icommand_names:
+				icommand_path_in = path.join(cmake_pfx_bin, icommand_script)
+				icommand_path_out = path.join(dest_bin, icommand_script)
+
+				shutil.copyfile(icommand_path_in, icommand_path_out)
+				os.chmod(icommand_path_out, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |  # noqa: E222,W504
+				                            stat.S_IRGRP |                stat.S_IXGRP |  # noqa: E127,E222,W504
+				                            stat.S_IROTH |                stat.S_IXOTH)  # noqa: E127,E222
+
+				icommand_names.remove(icommand_script)
+				self.icommand_scripts[icommand_script] = icommand_path_out
+
+		icommand_binaries = {path.join(cmake_pfx_bin, icb): path.join(dest_bin, icb) for icb in icommand_names}
+
+		results = self.strip_util.strip_and_clean_dispatch(icommand_binaries.items())
+		script_common.futures_wait(results)
+
+		icommand_binaries = {icb: path.join(dest_bin, icb) for icb in icommand_names}
+
+		self.icommand_binaries.update(icommand_binaries)
+
+	def _should_skip_plugin(self, plugfname: str) -> bool:
+		# assume that we can exclude any plugins that end with _server.[ext]
+		for suffix in self.options.sharedlib_suffixes:
+			if plugfname.endswith(suffix):
+				return plugfname.endswith('_server', 0, -len(suffix))
+		return False
+
+	def prepare_irods_runtime(self) -> NoReturn:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		self.context.status(l, '-- Gathering iRODS runtime libraries and plugins')
+
+		dest_lib = self.pkg_lib_dir
+		dest_plugins = self.pkg_plugs_dir
+
+		# for now, assume irods package prefix will always be specified
+		if path.isabs(self.options.irods_plugsdir):
+			src_plugins = self.options.irods_plugsdir
+		else:
+			src_plugins = path.join(self.options.irods_package_prefix, self.options.irods_plugsdir)
+
+		# for now, assume all we need are auth and network plugins
+		plugsdnames = ['auth', 'network']
+		plugsdirs = []
+
+		for plugsdname in plugsdnames:
+			src_plugsdir = path.join(src_plugins, plugsdname)
+			dest_plugsdir = path.join(dest_plugins, plugsdname)
+			if not path.exists(dest_plugsdir):
+				os.mkdir(dest_plugsdir)
+			plugsdirs.append((src_plugsdir, dest_plugsdir))
+
+		soname_map = {}
+		plugs = []
+		runtime_bins = {}
+
+		# for now, assume everything passed through --irods-externals-lib is in $/lib
+		# and that the filenames match the sonames
+		# and that there's no symlinking shenanigans
+		for lib_in in self.options.irods_runtime_libs:
+			soname = path.basename(lib_in)
+			dest_libpath = path.join(dest_lib, soname)
+			soname_map[soname] = dest_libpath
+			runtime_bins[lib_in] = dest_libpath
+
+		# continue assuming there's no symlinking shenanigans
+		for src_plugsdir, dest_plugsdir in plugsdirs:
+			for plugfname in os.listdir(src_plugsdir):
+				if self._should_skip_plugin(plugfname):
+					continue
+				dest_plugpath = path.join(dest_plugsdir, plugfname)
+				plugs.append(dest_plugpath)
+				runtime_bins[path.join(src_plugsdir, plugfname)] = dest_plugpath
+
+		results = self.strip_util.strip_and_clean_dispatch(runtime_bins.items())
+		script_common.futures_wait(results)
+
+		self.irods_runtime_libs.update(soname_map)
+		self.irods_runtime_plugs.update(plugs)
+		self.prepared_libs.update(soname_map)
+
+	def gather_ext_lib_paths(self) -> NoReturn:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		self.context.status(l, '-- Gathering library paths')
+
+		prepped_bins = itertools.chain(self.icommand_binaries.values(),
+			self.irods_runtime_libs.values(), self.irods_runtime_plugs)
+		ld_paths_res = [
+			self.executor.submit(self.elfinfo_util.get_lib_paths, pkg_bin)
+			for pkg_bin in prepped_bins
+		]
+
+		self.lib_directives.read_directives()
+
+		# As with most libs passed in from a buildsystem, we must assume that we are getting
+		# symlinks, and that the filenames do not match the soname
+		# For now, assume libc++ doesn't bring in additional deps
+		lib_paths_libcxx = {}
+		for libcxx_libpath in self.options.libcxx_libpaths:
+
+			# libc++.so is a linker script file. let's avoid having to parse those for now.
+			# libc++'s soversion has been '1' for a while now. let's assume that's not changing.
+			if libcxx_libpath.endswith('.so'):
+				libcxx_libpath = libcxx_libpath + '.1'
+
+			lib_paths_libcxx[path.basename(libcxx_libpath)] = libcxx_libpath
+
+		ld_paths = {}
+		ld_not_found = set()
+
+		for ld_r in reversed(ld_paths_res):
+			ld_res = ld_r.result()
+			ld_paths.update(ld_res.lib_paths)
+			ld_not_found.update(ld_res.not_found)
+			self.ldd_other_libs.update(ld_res.other_libs)
+
+		for soname, libpath in ld_paths.items():
+			if not libpath.startswith(self.pkg_dir_root) and soname not in self.prepared_libs:
+				self.ext_lib_paths[soname] = libpath
+		self.ext_lib_paths.update(lib_paths_libcxx)
+
+		ld_not_found.difference_update(self.ext_lib_paths)
+
+		if len(ld_not_found) > 0:
+			l.debug('ldd could not find some libs:\n%s', logging_ext.pformat(ld_not_found))
+
+		l.debug('other results from ldd:\n%s', logging_ext.pformat(self.ldd_other_libs))
+
+	def _prepare_library(self, lib_in: LibFsInfo) -> LibFsInfo:
+		soname = lib_in.soname
+
+		output_path = path.join(self.pkg_lib_dir, lib_in.fname)
+		output_ld_path = path.join(self.pkg_lib_dir, lib_in.soname)
+		self.strip_util.strip_and_clean(lib_in.real_path, output_path=output_path)
+
+		for linkname, linktgt in lib_in.links.items():
+			linkpath = path.join(self.pkg_lib_dir, linkname)
+			os.symlink(linktgt, linkpath)
+
+		return LibFsInfo(soname, output_ld_path)
+
+	def _prepare_libraries(self, libs_in: Iterable[LibFsInfo]) -> Sequence[LibFsInfo]:
+		prepped_res = [
+			self.executor.submit(self._prepare_library, lib_in)
+			for lib_in in libs_in
+		]
+
+		for lib_info_r in prepped_res:
+			lib_info = lib_info_r.result()
+			self.prepared_libs[lib_info.soname] = lib_info.real_path
+
+		return [r.result() for r in prepped_res]
+
+	def _filter_ext_libs(self, sonames: Iterable[str]) -> Iterable[LibFsInfo]:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		for soname in sonames:
+			if soname in self.prepared_libs or soname in self.untracked_libs or soname in self.lib_directives.denylist:
+				continue
+
+			libpath = self.ext_lib_paths.get(soname, None)
+
+			if soname not in self.lib_directives.allowlist:
+				self.untracked_libs[soname] = libpath
+				if self.options.permissive_liballowlist:
+					l.info('library %s not in library directives.', soname)
+				else:
+					l.warning('library %s not in library directives.  Skipping.', soname)
+					continue
+
+			if not libpath:
+				raise OSError(errno.ENOENT, 'path for ' + soname + ' not found')
+
+			yield LibFsInfo(soname, libpath)
+
+	def _get_needed_libs(self, bin_path: str) -> Sequence[str]:
+		elfinfo = self.elfinfo_util.get_elfinfo(bin_path)
+		return elfinfo.imported_libs
+
+	def _get_needed_libs_multi(self, bin_paths: Iterable[str]) -> Set[LibFsInfo]:
+		libs = set()
+		libs_res = [
+			self.executor.submit(self._get_needed_libs, bin_path)
+			for bin_path in bin_paths
+		]
+		for libs_r in libs_res:
+			libs.update(libs_r.result())
+		return libs
+
+	def prepare_ext_libs(self) -> NoReturn:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		self.context.status(l, '-- Gathering external libraries')
+
+		if not self.lief_info.lief_usable:
+			self._prepare_libraries(self._filter_ext_libs(self.ext_lib_paths.keys()))
+			return
+
+		prepped_bins = itertools.chain(self.icommand_binaries.values(),
+			self.irods_runtime_libs.values(), self.irods_runtime_plugs)
+		current_libs = list(self._filter_ext_libs(self._get_needed_libs_multi(prepped_bins)))
+		while len(current_libs) > 0:
+			pkg_libs = self._prepare_libraries(current_libs)
+			prepped_bins = [pkg_lib.ld_path for pkg_lib in pkg_libs]
+			current_libs = list(self._filter_ext_libs(self._get_needed_libs_multi(prepped_bins)))
+
+	def set_runpaths(self) -> NoReturn:
+		if not self.runpath_util.tool_state:
+			return
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		self.context.status(l, '-- Setting RUNPATHs')
+
+		libs_res = self.runpath_util.set_rpath_dispatch(self.prepared_libs.values(), '$ORIGIN')
+
+		bins_runpath = os.path.relpath(self.pkg_lib_dir, start=self.pkg_bin_dir)
+		if bins_runpath == '.':
+			bins_runpath = '$ORIGIN'
+		else:
+			bins_runpath = path.join('$ORIGIN', bins_runpath)
+		bins_res = self.runpath_util.set_rpath_dispatch(self.icommand_binaries.values(), bins_runpath)
+
+		plugs_runpath = os.path.relpath(self.pkg_lib_dir, start=self.pkg_plugs_dir)
+		if plugs_runpath == '.':
+			plugs_runpath = '$ORIGIN'
+		else:
+			plugs_runpath = path.join('$ORIGIN', plugs_runpath)
+		plugs_res = self.runpath_util.set_rpath_dispatch(self.irods_runtime_plugs, plugs_runpath)
+
+		res_all = script_common.CollectionCompoundView(
+			[libs_res, bins_res, plugs_res]
+		)
+		script_common.futures_wait(res_all)
+
+	def create_tarball(self) -> NoReturn:
+		l = logging.getLogger(__name__)  # noqa: VNE001,E741
+
+		self.context.status(l, '-- Creating tarball')
+
+		self.tar_util.create_tarball(self.pkg_dir, self.options.output_path)
+
+
+def _main() -> Optional[int]:
+	options = PackagerOptions()
+	options.parse_args()
+
+	augment_module_search_paths(options=options)
+
+	context = PackagerContext(options)
+	context.init_logging(options.verbosity)
+	logging_ext.setup_stacktrace_signal()
+
+	executor_type = concurrent.futures.ThreadPoolExecutor
+	max_workers = None
+	if context.lief_info.not_threadsafe:
+		# FIXME: ProcessPoolExecutor causes RuntimeError: Queue objects should only be shared...
+		#executor_type = concurrent.futures.ProcessPoolExecutor
+		max_workers = 1
+
+	with executor_type(max_workers=max_workers) as executor:
+		packager = Packager(context, executor)
+		packager.prepare_workspace()
+		packager.prepare_icommands()
+		packager.prepare_irods_runtime()
+		packager.gather_ext_lib_paths()
+		packager.prepare_ext_libs()
+		packager.set_runpaths()
+		packager.create_tarball()
+
+
+if __name__ == '__main__':
+	sys.exit(_main())

--- a/packaging/userspace/utilbase.py
+++ b/packaging/userspace/utilbase.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import sys, errno  # noqa: I201,I001; pylint: disable=C0410
+
+if __name__ == '__main__':
+	print(__file__ + ': This module is not meant to be invoked directly.',  # noqa: T001
+	      file=sys.stderr)
+	sys.exit(errno.ELIBEXEC)
+
+import shutil, os  # noqa: I100,I202; pylint: disable=C0410
+from abc import ABCMeta, abstractmethod
+from concurrent.futures import Executor, Future
+from types import ModuleType
+from typing import Generic, Optional, TypeVar
+
+from compat_shims import Callable, Iterable, Mapping, MutableMapping, NoReturn
+from context import OptionsT, PackagerContext, lief_ver_info
+from lief_instrumentation import LiefModuleT
+
+__all__ = [
+	'DummyExecutor',
+	'PackagerToolStateBase',
+	'PackagerToolState',
+	'PackagerOperationToolState',
+	'ToolStateT',
+	'PackagerUtilBase'
+]
+
+
+class DummyExecutor(Executor):
+
+	def submit(self, fn: Callable, *args, **kwargs) -> Future:  # noqa: ANN002,ANN003; pylint: disable=W0221
+		ret = Future()
+		try:
+			result = fn(*args, **kwargs)
+		except BaseException as ex:  # noqa: B902; pylint: disable=W0703
+			ret.set_exception(ex)
+		else:
+			ret.set_result(result)
+		return ret
+
+
+class PackagerToolStateBase(metaclass=ABCMeta):
+
+	@property
+	@abstractmethod
+	def is_usable(self) -> bool:
+		raise NotImplementedError()
+
+	@property
+	@abstractmethod
+	def path(self) -> Optional[str]:
+		raise NotImplementedError()
+
+	def __bool__(self) -> bool:
+		return self.is_usable
+
+
+ToolStateT = TypeVar('ToolStateT', bound=PackagerToolStateBase)
+
+
+class PackagerToolState(PackagerToolStateBase):
+
+	def __init__(self, is_usable: bool = True, path: Optional[str] = None):
+		super().__init__()
+		self._is_usable = is_usable
+		self._path = path
+
+	@property
+	def is_usable(self) -> bool:
+		return self._is_usable
+
+	@is_usable.setter
+	def is_usable(self, value: bool) -> NoReturn:
+		self._is_usable = value
+
+	@property
+	def path(self) -> Optional[str]:
+		return self._path
+
+	@path.setter
+	def path(self, value: Optional[str]) -> NoReturn:
+		self._path = value
+
+
+class PackagerOperationToolState(PackagerToolStateBase):
+
+	def __init__(self, tool_state: PackagerToolStateBase):
+		super().__init__()
+		self._tool_state = tool_state
+		self.tool_tried: bool = not tool_state.is_usable
+
+	@property
+	def is_usable(self) -> bool:
+		return self._tool_state.is_usable
+
+	@property
+	def path(self) -> Optional[str]:
+		return self._tool_state.path
+
+
+class PackagerUtilBase(Generic[OptionsT]):
+
+	def __init__(self, context: PackagerContext[OptionsT], executor: Optional[Executor] = None):
+		if executor is None:
+			executor = DummyExecutor()
+		self._context = context
+		self._executor = executor
+
+	@property
+	def context(self) -> PackagerContext[OptionsT]:
+		return self._context
+
+	@property
+	def options(self) -> Optional[OptionsT]:
+		return self.context.options
+
+	@property
+	def ilib(self) -> ModuleType:
+		return self.context.ilib
+
+	@property
+	def lief(self) -> Optional[LiefModuleT]:  # noqa: ANN201
+		return self.context.lief
+
+	@property
+	def lief_info(self) -> lief_ver_info:
+		return self.context.lief_info
+
+	@property
+	def executor(self) -> Executor:
+		return self._executor
+
+	def fill_out_envdict(
+		self,
+		envdict: Optional[Mapping[str, str]] = None
+	) -> MutableMapping[str, str]:
+		_env = os.environ.copy()
+		if envdict is None:
+			envdict = self.context.envdict
+		if envdict is not None:
+			_env.update(envdict)
+		return _env
+
+	def find_tool(
+		self, toolnames: Iterable[str],
+		*args: str,
+		raise_if_not_found: Optional[bool] = True,
+		prettyname: Optional[str] = None,
+		path: Optional[str] = None,
+		env: Optional[Mapping[str, str]] = None
+	) -> Optional[str]:
+		# if we have an item in *args, it's probably a provided path
+		# if it's truthy, return it
+		# this is a convenience feature so that options.value None checking can be delegated here
+		# if we have more than one item in *args, though, it's an error
+		if len(args) == 1 and args[0]:
+			return args[0]
+		elif len(args) > 1:
+			raise ValueError('unknown positional arguments')
+
+		# get PATH from envdict, if it's there
+		if env and 'PATH' in env:
+			# if path and env were specified, and env contains a 'PATH', panic
+			if path:
+				raise ValueError('both path and env with PATH specified')
+			path = env['PATH']
+
+		# check the context's envdict, too
+		if not path:
+			path = self.context.envdict.get('PATH', None)
+
+		for toolname in toolnames:
+			found_tool = shutil.which(toolname, path=path)
+			if found_tool:
+				return found_tool
+
+		if raise_if_not_found:
+			if not prettyname:
+				prettyname = next(iter(prettyname))
+
+			raise OSError(errno.ENOENT, 'Could not find ' + prettyname + ' tool')
+
+		return None

--- a/src/itouch.cpp
+++ b/src/itouch.cpp
@@ -1,8 +1,8 @@
-#include <irods/rodsClient.h>
-#include <irods/client_connection.hpp>
-#include <irods/irods_version.h>
-#include <irods/touch.h>
-#include <irods/irods_exception.hpp>
+#include "rodsClient.h"
+#include "client_connection.hpp"
+#include "irods_version.h"
+#include "touch.h"
+#include "irods_exception.hpp"
 
 #include "utility.hpp"
 


### PR DESCRIPTION
Introduce packaging functionality for a userspace tarball.
Addresses irods/irods#5082

The current implementation is separate from our CPack packaging.

Requires Python 3. I'm targeting 3.6/3.5 for master/4-2-stable, which should ensure compatibility with all distros we currently support.
Will use `lief` if it is available, and will scream if it's not.

Here's the current process:
1. CMake adds the `userspace-tarball` target to the makefile. This target invokes the `userspace-packager.py` script and passes in a ton of information.
2. The script invokes the installation makefile targets for the icommands, with the prefix set to a temporary workspace.
3. The icommands are stripped of unneeded symbols, and, if `lief` is available, any imported libraries that are no longer needed after stripping are removed from the dynamic entry table.
4. The iRODS runtime libraries exposed by the CMake configuration file in the `irods-dev` package are copied to the temporary workspace. They are stripped and cleaned just like the icommands.
5. The script attempts to collect the needed auth and network plugins. These libraries are not exposed by the CMake configuration file in the `irods-dev` package, so the script takes a really good educated guess as to their location and finds them in the filesystem. They are stripped and cleaned just like the icommands and iRODS runtime libraries.
6. The script will attempt to identify needed libraries that we provide (irods-externals). If `lief` is available, It will collect, strip, and clean direct dependencies of everything prepared so far, repeating until no more irods-externals are required. If `lief` is not available, the script will collect all irods-externals in one go.
7. The script will attempt to collect needed libraries that are provided by the distribution but not installed by default. This is where the `known_libs` files come in. Because we cannot detect at build-time whether or not a given library is installed by default, these files contain the sonames of any libraries that I have ever seen in the dependency tree for the icommands package and a marker indicating whether or not it is okay to include them in the userspace tarball. Distribution-provided libraries are usually built with `-Wl,--as-needed`, meaning it is not as important to strip and clean them as it is the binaries we provide. At the moment, I'm planning on doing it anyway.
8. If usable `lief`, `chrpath`, or `cmake` is available, the script will set the runpath of all the prepared binaries to use a relative path to point at the lib directory inside the package. If `lief` is available, it will also set the `DF_ORIGIN` flag. This ensures that the user won't need to set `LD_LIBRARY_PATH` when running any of the icommands. the `DF_ORIGIN` flag is necessary to tell the runtime linker to respect `$ORIGIN` in the runpath, even when the libraries are loaded via `libdl` (like our plugins, for example).
9. The tarball is created.

Here's what's left to be done:
- [x] Jenkins testing
- [x] Merge related PR in irods repo
- [x] Make sure tarballs build in docker containers for our supported distros
    - [x] Ubuntu Bionic
    - [x] Centos 7
- [x] Make sure tarballs work in vanilla docker containers for our supported distros
    - [x] Ubuntu Bionic
    - [x] Centos 7
- [x] Write a little build documentation or example script
- [x] Cleanup
- [x] Finish #212
- [x] Hack together tarballs for 4.2.8