### PR TITLE
[irods/irods#5360] Return more detailed codes in iphymv (master)

### DIFF
--- a/src/iphymv.cpp
+++ b/src/iphymv.cpp
@@ -33,25 +33,25 @@ main( int argc, char **argv ) {
 
     if ( status < 0 ) {
         printf( "Use -h for help.\n" );
-        exit( 1 );
+        return 1;
     }
 
     if ( myRodsArgs.help == True ) {
         usage();
-        exit( 0 );
+        return 0;
     }
 
     if ( argc - optind <= 0 ) {
         rodsLog( LOG_ERROR, "iphymv: no input" );
         printf( "Use -h for help.\n" );
-        exit( 2 );
+        return 1;
     }
 
     status = getRodsEnv( &myEnv );
 
     if ( status < 0 ) {
         rodsLogError( LOG_ERROR, status, "main: getRodsEnv error. " );
-        exit( 1 );
+        return 1;
     }
 
     status = parseCmdLinePath( argc, argv, optind, &myEnv,
@@ -60,7 +60,7 @@ main( int argc, char **argv ) {
     if ( status < 0 ) {
         rodsLogError( LOG_ERROR, status, "main: parseCmdLinePath error. " );
         printf( "Use -h for help.\n" );
-        exit( 1 );
+        return 1;
     }
 
     // =-=-=-=-=-=-=-
@@ -73,13 +73,15 @@ main( int argc, char **argv ) {
                       myEnv.rodsZone, 1, &errMsg );
 
     if ( conn == NULL ) {
-        exit( 2 );
+        // Failed to connect to the server
+        return 2;
     }
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        // Failed to authenticate as the configured user
         rcDisconnect( conn );
-        exit( 7 );
+        return 3;
     }
 
     status = phymvUtil( conn, &myEnv, &myRodsArgs, &rodsPathInp );
@@ -87,31 +89,74 @@ main( int argc, char **argv ) {
     printErrorStack( conn->rError );
     rcDisconnect( conn );
 
-    if ( status < 0 ) {
-        exit( 3 );
-    }
-    else {
-        exit( 0 );
+    // The following checks various error codes and returns different exit codes
+    // so that the caller can take actions based on said codes (e.g. examine
+    // error code for feasibility of a retry).
+    const auto irods_error = getIrodsErrno(status);
+    switch (irods_error) {
+        case USER_CHKSUM_MISMATCH:
+            // The checksum on the destination replica is wrong, indicating corruption.
+            return 4;
+
+        case USER_INPUT_PATH_ERR:
+            // The specified logical path does not exist, indicating a user error.
+            return 5;
+
+        case UNIX_FILE_CREATE_ERR:
+        case UNIX_FILE_OPEN_ERR:
+        case UNIX_FILE_WRITE_ERR:
+            // Return a special error code if there is no space left on the device.
+            // All other UNIX filesystem-related errors get a separate, but still special error code.
+            return ENOSPC == getErrno(status) ? 6 : 7;
+
+        default:
+            break;
     }
 
-}
+    // For any other errors, return 3 as has been done historically for minimal surprises.
+    return status < 0 ? 3 : 0;
+} // main
 
 void
 usage() {
 
     char *msgs[] = {
-        "Usage: iphymv [-hMrvV] [-n replNum] [-S srcResource]  [-R destResource] ",
+        "Usage: iphymv [-hMrvV] [-n replNum] [-S srcResource] [-R destResource] ",
         "dataObj|collection ... ",
         " ",
         "Physically move a file in iRODS to another storage resource.",
         " ",
+        "The source replica must be specified by its full hierarchy and it must",
+        "exist at the provided resource hierarchy location. The resource hierarchy",
+        "for the destination replica must also be specified in full, but may or may",
+        "not exist at the specified location. Specifying a leaf resource is acceptable",
+        "in lieu of a full resource hierarchy as it can be reverse-resolved to the root.",
+        "See these example usages:",
+        "  iphymv -S demoResc -R 'pt1;r1;s1' /tempZone/home/alice/test.txt",
+        "  iphymv -S demoResc -R 's1' /tempZone/home/alice/test.txt",
+        " ",
+        "If the leaf resource targeted for a phymv refers to the archive of a compound",
+        "resource hierarchy, DIRECT_ARCHIVE_ACCESS will be returned because direct access",
+        "to an archive resource is not allowed.",
+        " ",
+        "iphymv cannot overwrite a replica which is not marked stale.",
+        "iphymv cannot move a replica which is not at rest.",
+        "iphymv cannot move a replica which is part of an already locked data object.",
+        " ",
+        "iphymv returns a few unique error codes based on the type of error which",
+        "occurred within the system:",
+        "  0: Success",
+        "  1: There was a problem with the client configuration or parsing the user input",
+        "  2: There was a problem connecting to the iRODS server (rcConnect failed)",
+        "  3: Historic exit code returned for all errors other than those listed above and below",
+        "  4: There was a mismatch between the source and destination replica's checksums",
+        "  5: There was a problem with the supplied source logical path",
+        "  6: The resource to host the destination replica has run out of space (ENOSPC)",
+        "  7: The source or destination replica failed to be opened for any other reason",
+        " ",
         "Note that if the source copy has a checksum value associated with it,",
         "a checksum will be computed for the replicated copy and compared with",
         "the source value for verification.",
-        " ",
-        "Note that if the source or destination resource is within a hierarchy,",
-        "a full resource hierarchy (semicolon delimited) must be specified:",
-        "  iphymv -S demoResc -R 'pt1;r1;s1' /tempZone/home/alice/test.txt",
         " ",
         "Options are:",
         " -r  recursive - phymove the whole subtree",
@@ -119,7 +164,6 @@ usage() {
         " -n  replNum  - the replica to be phymoved, typically not needed",
         " -S  srcResource - specifies the source resource for the move.",
         "     If specified, the replica stored on this resource will be moved.",
-        "     Otherwise, any one of the replicas will be moved",
         " -R  destResource - specifies the destination resource for the move.",
         "     This can also be specified, in your environment or via a rule",
         "     set up by the administrator.",


### PR DESCRIPTION
This change introduces more exit codes to iphymv based on a family of
error codes returned from the server in rsDataObjPhymv. Doing so allows
system implementers to take action based on a number of common use cases
such as retrying in the face of connection/network errors versus the
target replica being written to a node with a full disk.

---

Also added some more help text.

Should I add tests to irods/irods for the new error codes? Not sure how to easily trigger some of these situations...

Error codes...

0. Testing success is pretty extensive already
1. Testing various invalid inputs to `iphymv`, checking for error code 1
2. Testing failure to connect to server could just stop the server and run `iphymv`
3. Testing failure to authenticate as current user or anything besides codes 0-2 and 4-7 would involve a number of tests
4. Testing checksum mismatch would likely involve using https://github.com/irods/mungefs
5. This is already captured in a test for invalid inputs to `iphymv`, but could check for the new error code
6. Not sure if mungefs is able to simulate disk full events, but that would be needed for this one
7. Any other open failures could probably be simulated by mungefs

Let me know if you have thoughts about the tests. CI tests running