### PR TITLE
[irods/irods#5845] include api plugins in userspace tarball (master)

### DIFF
--- a/packaging/userspace/userspace-packager.py
+++ b/packaging/userspace/userspace-packager.py
@@ -308,7 +308,7 @@ class Packager(PackagerUtilBase[PackagerOptions]):
 			src_plugins = path.join(self.options.irods_package_prefix, self.options.irods_plugsdir)
 
 		# for now, assume all we need are auth and network plugins
-		plugsdnames = ['auth', 'network']
+		plugsdnames = ['auth', 'network', 'api']
 		plugsdirs = []
 
 		for plugsdname in plugsdnames:


### PR DESCRIPTION
Fixes irods/irods#5845 for master.
I haven't actually tested this against a running server yet.

My plan was to include GCC/libstdc++ compatibility changes in this PR (there might have to be special handling for libstdc++ like there is for libc++), but it turns out the problem with the GCC build that I was running into isn't actually related to packaging at all.