### PR TITLE
avoid USER_INCOMPATIBLE_PARAMS in Phymv rule file test (4-2-stable)

### DIFF
--- a/test/rules/rulemsiDataObjPhymv.r
+++ b/test/rules/rulemsiDataObjPhymv.r
@@ -12,5 +12,5 @@ myTestRule {
   msiDataObjPhymv(*SourceFile,*DestResource,*SourceResource,*ReplicaNumber,"null",*Status);
   writeLine("stdout","Replica number *ReplicaNumber of file *SourceFile is moved from resource *SourceResource to resource *DestResource");
 }
-INPUT *SourceFile="/tempZone/home/rods/forphymv/phymvfile", *DestResource="testallrulesResc", *SourceResource="demoResc", *ReplicaNumber="0"
+INPUT *SourceFile="/tempZone/home/rods/forphymv/phymvfile", *DestResource="testallrulesResc", *SourceResource="demoResc", *ReplicaNumber="null"
 OUTPUT ruleExecOut


### PR DESCRIPTION
corequisite with PR: https://github.com/irods/irods/pull/6206
(issue: https://github.com/irods/irods/issues/6169)