### PR TITLE
[irods/irods#6261] Declare that the icommands debian package provides itself (4-2-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,6 +446,7 @@ set(CPACK_ARCHIVE_COMPONENT_INSTALL OFF)
 
 set(CPACK_DEBIAN_PACKAGE_NAME "irods-icommands")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime (= ${IRODS_VERSION}), libc6, libssl1.0.0")
+set(CPACK_DEBIAN_PACKAGE_PROVIDES "irods-icommands (= ${IRODS_VERSION})")
 set(CPACK_DEBIAN_PACKAGE_REPLACES "irods-icat, irods-resource")
 
 set(CPACK_RPM_PACKAGE_NAME "irods-icommands")


### PR DESCRIPTION
Addresses irods/irods#6261 for this repo for 4-2-stable