### PR TITLE
[irods/irods_6276] Update userspace tarball packager

### DIFF
--- a/packaging/userspace/compat_shims.py
+++ b/packaging/userspace/compat_shims.py
@@ -191,16 +191,6 @@ else:
 	Tuple = tuple
 	Type = type
 
-# platform.linux_distribution was deprecated in 3.5 and removed in 3.8
-# the distro package is the recommended replacement
-try:
-	from distro import linux_distribution
-except ImportError:
-	if sys.version_info < (3, 8):
-		from platform import linux_distribution
-	else:
-		raise
-
 __all__ = [
 	'Version',
 	'parse_version',
@@ -229,6 +219,5 @@ __all__ = [
 	'Set',
 	'DefaultDict',
 	'Tuple',
-	'Type',
-	'linux_distribution'
+	'Type'
 ]

--- a/packaging/userspace/elfinfo_util.py
+++ b/packaging/userspace/elfinfo_util.py
@@ -394,7 +394,10 @@ class DynamicSectionTable(
 		if len(args) > 1:
 			raise ValueError('Too many positional arguments')
 
-		MutableMapping.__init__(self)  # pylint: disable=W0233
+		try:
+			MutableMapping.__init__(self)  # pylint: disable=W0233
+		except TypeError:
+			pass
 		DynamicSectionTableBase.__init__(self, OrderedDict(*args))  # pylint: disable=W0233
 
 		self._source = source

--- a/packaging/userspace/externs_libs.common
+++ b/packaging/userspace/externs_libs.common
@@ -14,21 +14,10 @@
 #
 # This file contains directives that are more or less universal for all distros we might support
 
-libarchive
-libavrocpp
-libboost_atomic
 libboost_chrono
 libboost_filesystem
-libboost_iostreams
 libboost_program_options
-libboost_random
-libboost_regex
-libboost_signals
-libboost_system
 libboost_thread
-libboost_timer
 libc++
 libc++abi
 libfmt
-libnanodbc
-libzmq

--- a/packaging/userspace/known_libs.centos7
+++ b/packaging/userspace/known_libs.centos7
@@ -14,22 +14,6 @@
 # Unfortunately, we cannot detect whether or not a given library is installed by default without
 # introducing unreasonable package-time requirements.
 
--libbz2.so.1
--libcom_err.so.2
 -libcrypto.so.10
--libgssapi_krb5.so.2
--libk5crypto.so.3
--libkeyutils.so.1
--libkrb5.so.3
--libkrb5support.so.0
--liblzma.so.5
--libpcre.so.1
 -libssl.so.10
--libxml2.so.2
 -libcurl.so.4
-
-# libtool-ltdl package is not installed by default
-+libltdl.so.7
-
-# unixODBC package is not installed by default
-+libodbc.so.2

--- a/packaging/userspace/known_libs.centos7
+++ b/packaging/userspace/known_libs.centos7
@@ -4,6 +4,7 @@
 # Each line lists the soname of a library.
 # Lines starting with + denote a library that may be included.
 # Lines starting with - denote a library that must be excluded.
+# Lines starting with ~ denote that a previous directive should be ignored
 # Blank lines are ignored.
 # Lines starting with # are ignored.
 #

--- a/packaging/userspace/known_libs.common
+++ b/packaging/userspace/known_libs.common
@@ -4,6 +4,7 @@
 # Each line lists the soname of a library.
 # Lines starting with + denote a library that may be included.
 # Lines starting with - denote a library that must be excluded.
+# Lines starting with ~ denote that a previous directive should be ignored
 # Blank lines are ignored.
 # Lines starting with # are ignored.
 #

--- a/packaging/userspace/known_libs.debian11
+++ b/packaging/userspace/known_libs.debian11
@@ -1,0 +1,57 @@
+# This file helps our userspace tarball packager figure out what distro-provided libraries should
+# be bundled with our icommands.
+#
+# Each line lists the soname of a library.
+# Lines starting with + denote a library that may be included.
+# Lines starting with - denote a library that must be excluded.
+# Blank lines are ignored.
+# Lines starting with # are ignored.
+#
+# RATIONALE: There is a need for userspace packages for environments in which the user may not be
+# authorized to install packages on the system. Therefore, we provide the option to bundle any
+# distro-provided dependencies that are not installed by default.
+# Unfortunately, we cannot detect whether or not a given library is installed by default without
+# introducing unreasonable package-time requirements.
+
+-libidn2.so.0
+-libgnutls.so.30
+-libnettle.so.8
+-libgmp.so.10
+-libhogweed.so.6
+-libunistring.so.2
+-libgcrypt.so.20
+
+# libssl1.1 installed by default in debian
+-libcrypto.so.1.1
+-libssl.so.1.1
+
+# libgssapi-krb5-2 installed by default in debian
+-libgssapi_krb5.so.2
+
+# Let's assume we're building against libcurl4-gnutls-dev
+
+# libcurl3-gnutls
++libcurl-gnutls.so.4
+
+# libssh2-1
++libssh2.so.1
+
+# libbrotli1
++libbrotlidec.so.1
++libbrotlicommon.so.1
+
+# libldap-2.4-2
++libldap_r-2.4.so.2
++liblber-2.4.so.2
+
+# libpsl5
++libpsl.so.5
+
+# libnghttp2-14
++libnghttp2.so.14
+
+# librtmp1
++librtmp.so.1
+
+# libsasl2-2
++libsasl2.so.2

--- a/packaging/userspace/known_libs.debian11
+++ b/packaging/userspace/known_libs.debian11
@@ -4,6 +4,7 @@
 # Each line lists the soname of a library.
 # Lines starting with + denote a library that may be included.
 # Lines starting with - denote a library that must be excluded.
+# Lines starting with ~ denote that a previous directive should be ignored
 # Blank lines are ignored.
 # Lines starting with # are ignored.
 #

--- a/packaging/userspace/known_libs.el8
+++ b/packaging/userspace/known_libs.el8
@@ -1,0 +1,19 @@
+# This file helps our userspace tarball packager figure out what distro-provided libraries should
+# be bundled with our icommands.
+#
+# Each line lists the soname of a library.
+# Lines starting with + denote a library that may be included.
+# Lines starting with - denote a library that must be excluded.
+# Lines starting with ~ denote that a previous directive should be ignored
+# Blank lines are ignored.
+# Lines starting with # are ignored.
+#
+# RATIONALE: There is a need for userspace packages for environments in which the user may not be
+# authorized to install packages on the system. Therefore, we provide the option to bundle any
+# distro-provided dependencies that are not installed by default.
+# Unfortunately, we cannot detect whether or not a given library is installed by default without
+# introducing unreasonable package-time requirements.
+
+-libcrypto.so.1.1
+-libssl.so.1.1
+-libcurl.so.4

--- a/packaging/userspace/known_libs.ubuntu18
+++ b/packaging/userspace/known_libs.ubuntu18
@@ -13,8 +13,6 @@
 # Unfortunately, we cannot detect whether or not a given library is installed by default without
 # introducing unreasonable package-time requirements.
 
--libbz2.so.1.0
--liblzma.so.5
 -libidn2.so.0
 -libgnutls.so.30
 -libnettle.so.6
@@ -27,19 +25,6 @@
 # libssl
 +libcrypto.so.1.1
 +libssl.so.1.1
-
-# libicu60
-+libicudata.so.60
-+libicuuc.so.60
-
-# libxml2
-+libxml2.so.2
-
-# libltdl7
-+libltdl.so.7
-
-# libodbc1
-+libodbc.so.2
 
 # Let's assume we're building against libcurl4-gnutls-dev
 

--- a/packaging/userspace/known_libs.ubuntu18
+++ b/packaging/userspace/known_libs.ubuntu18
@@ -4,6 +4,7 @@
 # Each line lists the soname of a library.
 # Lines starting with + denote a library that may be included.
 # Lines starting with - denote a library that must be excluded.
+# Lines starting with ~ denote that a previous directive should be ignored
 # Blank lines are ignored.
 # Lines starting with # are ignored.
 #

--- a/packaging/userspace/known_libs.ubuntu20
+++ b/packaging/userspace/known_libs.ubuntu20
@@ -4,6 +4,7 @@
 # Each line lists the soname of a library.
 # Lines starting with + denote a library that may be included.
 # Lines starting with - denote a library that must be excluded.
+# Lines starting with ~ denote that a previous directive should be ignored
 # Blank lines are ignored.
 # Lines starting with # are ignored.
 #

--- a/packaging/userspace/known_libs.ubuntu20
+++ b/packaging/userspace/known_libs.ubuntu20
@@ -1,0 +1,100 @@
+# This file helps our userspace tarball packager figure out what distro-provided libraries should
+# be bundled with our icommands.
+#
+# Each line lists the soname of a library.
+# Lines starting with + denote a library that may be included.
+# Lines starting with - denote a library that must be excluded.
+# Blank lines are ignored.
+# Lines starting with # are ignored.
+#
+# RATIONALE: There is a need for userspace packages for environments in which the user may not be
+# authorized to install packages on the system. Therefore, we provide the option to bundle any
+# distro-provided dependencies that are not installed by default.
+# Unfortunately, we cannot detect whether or not a given library is installed by default without
+# introducing unreasonable package-time requirements.
+
+-libidn2.so.0
+-libgnutls.so.30
+-libnettle.so.7
+-libgmp.so.10
+-libhogweed.so.5
+-libunistring.so.2
+-libcom_err.so.2
+-libcrypt.so.1
+
+# libssl
++libcrypto.so.1.1
++libssl.so.1.1
+
+# Let's assume we're building against libcurl4-gnutls-dev
+
+# libcurl4-gnutls
++libcurl-gnutls.so.4
+
+# libssh-4
++libssh.so.4
+
+# libbrotli1
++libbrotlidec.so.1
++libbrotlicommon.so.1
+
+# libgssapi-krb5-2
++libgssapi_krb5.so.2
+
+# libldap-2.4-2
++libldap_r-2.4.so.2
++liblber-2.4.so.2
+
+# libpsl5
++libpsl.so.5
+
+# libnghttp2-14
++libnghttp2.so.14
+
+# librtmp1
++librtmp.so.1
+
+# libgssapi3-heimdal
++libgssapi.so.3
+
+# libsasl2-2
++libsasl2.so.2
+
+# libk5crypto3
++libk5crypto.so.3
+
+# libkrb5-3
++libkrb5.so.3
+
+# libkrb5support0
++libkrb5support.so.0
+
+# libkeyutils1
++libkeyutils.so.1
+
+# libroken18-heimdal
++libroken.so.18
+
+# libasn1-8-heimdal
++libasn1.so.8
+
+# libhcrypto4-heimdal
++libhcrypto.so.4
+
+# libkrb5-26-heimdal
++libkrb5.so.26
+
+# libheimntlm0-heimdal
++libheimntlm.so.0
+
+# libheimbase1-heimdal
++libheimbase.so.1
+
+# libhx509-5-heimdal
++libhx509.so.5
+
+# libsqlite3-0
++libsqlite3.so.0
+
+# libwind0-heimdal
++libwind.so.0

--- a/packaging/userspace/libdirectives.py
+++ b/packaging/userspace/libdirectives.py
@@ -205,6 +205,10 @@ class LibDirectives(PackagerUtilBase[LibDirectiveOptionsBase]):
 						soname = directive_l[1:]
 						self.allowlist.sonames.discard(soname)
 						self.denylist.sonames.add(soname)
+					elif directive_l[0] == '~':
+						soname = directive_l[1:]
+						self.allowlist.sonames.discard(soname)
+						self.denylist.sonames.discard(soname)
 					else:
 						l.warning('%s:%s: Syntax error, ignoring line', soname_dfname, str(lnum))
 		else:

--- a/packaging/userspace/lief_instrumentation.py
+++ b/packaging/userspace/lief_instrumentation.py
@@ -123,6 +123,7 @@ class lief_ver_info():
 		self._rebuild_is_slow = None
 		self._old_logger_api = None
 		self._not_threadsafe = None
+		self._fragile_builder = None
 
 		if lief:
 			self._lief_imported = True
@@ -137,6 +138,7 @@ class lief_ver_info():
 				older_than_0_11_0 = self._lief_version < PkgVersion('0.11.0')
 				older_than_0_12_0 = self._lief_version < PkgVersion('0.12.0')
 
+				self._fragile_builder = older_than_0_12_0
 				self._rebuild_is_slow = older_than_0_12_0
 				self._rebuild_is_reallyslow = older_than_0_11_0
 				self._old_logger_api = older_than_0_11_0
@@ -153,6 +155,10 @@ class lief_ver_info():
 	@property
 	def lief_usable(self) -> bool:
 		return self._lief_usable
+
+	@property
+	def fragile_builder(self) -> bool:
+		return self._fragile_builder
 
 	@property
 	def rebuild_is_slow(self) -> bool:

--- a/packaging/userspace/pyproject.toml
+++ b/packaging/userspace/pyproject.toml
@@ -290,7 +290,7 @@ ignore = [
 	'D107',
 ]
 
-[tool.flakehell]
+[tool.flakeheaven]
 min-python-version = '3.6.0'
 mypy-init-return = true
 max_line_length = 100
@@ -314,7 +314,7 @@ application-import-names = [
 	'utilbase',
 ]
 
-[tool.flakehell.plugins]
+[tool.flakeheaven.plugins]
 pylint = [ '+*' ]
 pyflakes = [ '+*' ]
 pycodestyle = [
@@ -387,8 +387,8 @@ flake8-commas = [ '-*' ]
 flake8-fixme = [ '-*' ]
 flake8-isort = [ '-*' ]
 
-[tool.flakehell.exceptions."log_instrumentation.py"]
+[tool.flakeheaven.exceptions."log_instrumentation.py"]
 pycodestyle = [ '-E221' ]  # multiple spaces before operator
 
-[tool.flakehell.exceptions."compat_shims.py"]
+[tool.flakeheaven.exceptions."compat_shims.py"]
 pycodestyle = [ '-E301' ]  # expected x blank lines, found y

--- a/packaging/userspace/strip_util.py
+++ b/packaging/userspace/strip_util.py
@@ -204,7 +204,7 @@ class StripUtil(PackagerUtilBase[StripUtilOptionsBase]):
 		lief = self.lief
 
 		# lief tends to segfault with libc++
-		if fname.startswith('libc++.') or fname.startswith('libc++abi.'):
+		if self.lief_info.fragile_builder and (fname.startswith('libc++.') or fname.startswith('libc++abi.')):
 			unneeded_libs = []
 		else:
 			unneeded_libs = self.libinfo_util.get_unused_dependencies(bin_path)

--- a/packaging/userspace/userspace-packager.py
+++ b/packaging/userspace/userspace-packager.py
@@ -136,7 +136,7 @@ class Packager(PackagerUtilBase[PackagerOptions]):
 		if self.options.set_origin_flag is None and (
 			self.options.target_platform == 'centos' and self.options.target_platform_variant == '7'
 		):
-			self.options.set_origin_flag = False
+			self.options.set_origin_flag = not self.lief_info.fragile_builder
 
 		context.lief_info.check_and_whine()
 		self.elfinfo_util = ElfInfoUtil(context, executor=executor, raise_if_ldd_not_found=True)

--- a/packaging/userspace/userspace-packager.py
+++ b/packaging/userspace/userspace-packager.py
@@ -11,9 +11,11 @@ from concurrent.futures import Executor
 from os import path
 from typing import Optional
 
+from distro import linux_distribution
+
 import script_common
 import log_instrumentation as logging_ext
-from compat_shims import Iterable, NoReturn, Sequence, Set, linux_distribution
+from compat_shims import Iterable, NoReturn, Sequence, Set
 from context import PackagerContext, PackagerOptionsBase, augment_module_search_paths
 from options import RunArgOption
 from utilbase import PackagerUtilBase

--- a/packaging/userspace/utilbase.py
+++ b/packaging/userspace/utilbase.py
@@ -16,8 +16,8 @@ from types import ModuleType
 from typing import Generic, Optional, TypeVar
 
 from compat_shims import Callable, Iterable, Mapping, MutableMapping, NoReturn
-from context import OptionsT, PackagerContext, lief_ver_info
-from lief_instrumentation import LiefModuleT
+from context import OptionsT, PackagerContext
+from lief_instrumentation import LiefModuleT, lief_ver_info
 
 __all__ = [
 	'DummyExecutor',


### PR DESCRIPTION
This PR does the following:
- [x] Updates the userspace packager's `pyproject.toml` to use `flakeheaven` instead of the abandoned `flakehell`
- [x] Fixes a bug in `utilbase.py` where `lief_ver_info` was being imported from the wrong place
- [x] Bumps the recommended version of LIEF to 0.12.
- [x] Adjusts warning threshold handling for slow ELF rebuilds as the ELF rebuilder in LIEF 0.12 is much faster than both 0.11 and 0.10's.
- [x] Marks LIEF's ELF rebuilder as fragile for versions prior to 0.12 and only performs segfault workarounds for fragile ELF rebuilders.
- Updates directive files for supported distros
    - [x] CentOS 7
    - [x] Ubuntu 18.04
- Adds directive files for newly supported distros
    - [x] Ubuntu 20.04
    - [x] Debian 11
    - [x] AlmaLinux 8
    - [x] Rocky Linux 8
- ~~Conditionally cleans out unneeded library imports with dangling symbol versions (lief-project/LIEF#670)~~ - later


Tested in containers:
- [x] CentOS 7
- [x] Ubuntu 18.04
- [x] Ubuntu 20.04
- [x] Debian 11
- [x] AlmaLinux 8
- [x] Rocky Linux 8


Closes irods/irods#6276