### PR TITLE
[irods/irods#6626] Remove ellipsis from ifsck help text (main)

### DIFF
--- a/src/ifsck.cpp
+++ b/src/ifsck.cpp
@@ -129,7 +129,7 @@ main( int argc, char **argv ) {
 void
 usage() {
     char *msgs[] = {
-        "Usage: ifsck [-hKrR] srcPhysicalFile|srcPhysicalDirectory ... ",
+        "Usage: ifsck [-hKrR] srcPhysicalFile|srcPhysicalDirectory",
         " ",
         "Check if a local file or local directory content is",
         "consistent in size (and optionally its checksum) with its",


### PR DESCRIPTION
Addresses irods/irods#6626 / irods/irods#6051

Its presence suggests that ifsck takes multiple paths per invocation when in fact it does not.