### PR TITLE
[irods/irods#6887] send scrambled password only if param not empty (4-2-stable)

### DIFF
--- a/src/igroupadmin.cpp
+++ b/src/igroupadmin.cpp
@@ -291,7 +291,8 @@ doCommand( char *cmdToken[] ) {
     }
 
     if ( strcmp( cmdToken[0], "mkuser" ) == 0 ) {
-        userAdmin( "mkuser", cmdToken[1], setScrambledPw( cmdToken[2] ),
+        char empty_string[] = "";
+        userAdmin( "mkuser", cmdToken[1], *cmdToken[2] ? setScrambledPw(cmdToken[2]) : empty_string,
                    cmdToken[3], "", "", "", "" );
         return 0;
     }
@@ -333,8 +334,8 @@ main( int argc, char **argv ) {
 
     int argOffset;
 
-    int maxCmdTokens = 20;
-    char *cmdToken[20];
+    constexpr int maxCmdTokens = 20;
+    char *cmdToken[maxCmdTokens];
     int keepGoing;
     int firstTime;
 


### PR DESCRIPTION
Corresponds to changes in https://github.com/irods/irods/pull/6889 . `igroupadmin` was scrambling an empty password string when the  password parameter was not provided; this fixes that oversight.