### PR TITLE
[_371] remove <cassert> include

### DIFF
--- a/src/itree.cpp
+++ b/src/itree.cpp
@@ -13,7 +13,6 @@
 #include "boost/program_options.hpp"
 #include "json.hpp"
 
-#include <cassert>
 #include <regex>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
A correction for `4-2-stable` only, as #340 is already merged with  an unnecessary `#include <cassert>`  [that sneaked in](https://github.com/irods/irods_client_icommands/pull/340/files#diff-2e6ca6ed53b52ed21049080a7ba80fb31aa8749940e967e466ec26a31bed972aR16) to the merged code.  Within the corresponding pulls (#369 and #370) to other branches, not yet merged, this change need not result in an additional pull request and may even be integrated into the main commit.
