### PR TITLE
[irods/irods_6627] Output better error messages for invalid path arguments (4-3-stable)

### DIFF
--- a/src/itree.cpp
+++ b/src/itree.cpp
@@ -123,6 +123,11 @@ int main(int argc, char** argv){
         load_client_api_plugins();
         irods::experimental::client_connection conn;
 
+        if (!fs::client::is_collection(conn, path)) {
+            std::cerr << "Error: The specified path does not refer to a collection.\n";
+            return 1;
+        }
+
         if (vm["json"].as<bool>()) {
             auto value = get_json(path, vm, conn, vm["depth"].as<int>() );
             json::json top;


### PR DESCRIPTION
Cherry-picked from https://github.com/irods/irods_client_icommands/pull/389

If the logical path argument given to itree is not an existing collection, we call this an error and return prematurely.