### PR TITLE
[irods/irods 7048] Add printErrorStack after login (main)

### DIFF
--- a/src/iadmin.cpp
+++ b/src/iadmin.cpp
@@ -7,6 +7,7 @@
 #include <irods/parseCommandLine.h>
 #include <irods/query_builder.hpp>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/rodsErrorTable.h>
 #include <irods/rodsLog.h>
 #include <irods/user_administration.hpp>
@@ -15,6 +16,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdio>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -1805,6 +1807,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         return 3;
     }
 

--- a/src/iapitest.cpp
+++ b/src/iapitest.cpp
@@ -4,13 +4,15 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/lsUtil.h>
 #include <irods/irods_buffer_encryption.hpp>
+
+#include <cstdio>
 #include <string>
 #include <iostream>
-
 
 // =-=-=-=-=-=-=-
 // NOTE:: these track the same structs in
@@ -74,6 +76,7 @@ main( int argc, char** argv ) {
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             exit( 7 );
         }

--- a/src/ibun.cpp
+++ b/src/ibun.cpp
@@ -6,9 +6,13 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/bunUtil.h>
+
+#include <cstdio>
+
 void usage();
 
 int
@@ -77,6 +81,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/icd.cpp
+++ b/src/icd.cpp
@@ -8,8 +8,11 @@
 #include <irods/rcMisc.h>
 #include <irods/genQuery.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage( char *prog );
 
@@ -71,6 +74,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         rcDisconnect( Conn );
         exit( 7 );
     }

--- a/src/ichksum.cpp
+++ b/src/ichksum.cpp
@@ -1,9 +1,12 @@
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/chksumUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -70,6 +73,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/ichmod.cpp
+++ b/src/ichmod.cpp
@@ -1,9 +1,11 @@
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 
+#include <cstdio>
 
 void usage();
 
@@ -70,6 +72,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         return 6;
     }

--- a/src/iclienthints.cpp
+++ b/src/iclienthints.cpp
@@ -4,13 +4,15 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/lsUtil.h>
 #include <irods/irods_buffer_encryption.hpp>
+
+#include <cstdio>
 #include <string>
 #include <iostream>
-
 
 void usage() {
     const char *msgs[] = {
@@ -86,6 +88,7 @@ main( int _argc, char** argv ) {
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             exit( 7 );
         }

--- a/src/icp.cpp
+++ b/src/icp.cpp
@@ -5,12 +5,15 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/cpUtil.h>
 #include <irods/rcGlobalExtern.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -85,6 +88,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/ifsck.cpp
+++ b/src/ifsck.cpp
@@ -4,9 +4,13 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/fsckUtil.h>
+
+#include <cstdio>
+
 void usage();
 
 static int set_genquery_inp_from_physical_path_using_hostname(genQueryInp_t* genquery_inp, const char* physical_path, const char* hostname) {
@@ -99,6 +103,7 @@ main( int argc, char **argv ) {
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             return 7;
         }

--- a/src/iget.cpp
+++ b/src/iget.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/getUtil.h>
@@ -12,6 +13,8 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/irods_parse_command_line_options.hpp>
+
+#include <cstdio>
 
 void usage( FILE* );
 
@@ -76,6 +79,7 @@ main( int argc, char **argv ) {
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             return 7;
         }

--- a/src/igroupadmin.cpp
+++ b/src/igroupadmin.cpp
@@ -3,8 +3,11 @@
 
 #include <irods/rods.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 rcComm_t *Conn;
 
@@ -411,6 +414,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         rcDisconnect( Conn );
         exit( 3 );
     }

--- a/src/ils.cpp
+++ b/src/ils.cpp
@@ -5,10 +5,12 @@
 #include <irods/lsUtil.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/rodsPath.h>
 
 #include <fmt/core.h>
 
+#include <cstdio>
 #include <iostream>
 #include <string>
 
@@ -75,6 +77,7 @@ main( int argc, char **argv ) {
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             exit( 7 );
         }

--- a/src/ilsresc.cpp
+++ b/src/ilsresc.cpp
@@ -5,8 +5,10 @@
 #include <irods/irods_resource_constants.hpp>
 #include <irods/rods.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/rodsErrorTable.h>
 
+#include <cstdio>
 #include <iostream>
 #include <vector>
 
@@ -505,6 +507,7 @@ main( int argc, char **argv ) {
 
         status = clientLogin( Conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(Conn->rError, stderr);
             return 3;
         }
 

--- a/src/imcoll.cpp
+++ b/src/imcoll.cpp
@@ -8,9 +8,13 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/mcollUtil.h>
+
+#include <cstdio>
+
 void usage();
 
 int
@@ -101,6 +105,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/imeta.cpp
+++ b/src/imeta.cpp
@@ -2,6 +2,7 @@
 
 #include <irods/rods.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/rodsPath.h>
@@ -2160,6 +2161,7 @@ int main( int argc, const char **argv )
     const auto disconnect = irods::at_scope_exit{[] { rcDisconnect(Conn); }};
 
     if ( clientLogin( Conn ) != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         return 3;
     }
 

--- a/src/imkdir.cpp
+++ b/src/imkdir.cpp
@@ -5,11 +5,14 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/mkdirUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -69,6 +72,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/imv.cpp
+++ b/src/imv.cpp
@@ -5,11 +5,14 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/mvUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage( char *program );
 
@@ -76,6 +79,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/ipasswd.cpp
+++ b/src/ipasswd.cpp
@@ -4,12 +4,14 @@
 /* User command to change their password. */
 #include <irods/rods.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <unistd.h>
 #include <termios.h>
 #include <irods/termiosUtil.hpp>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 
+#include <cstdio>
 #include <iostream>
 #include <string>
 
@@ -105,6 +107,7 @@ main( int argc, char **argv ) {
     /* and check that the user/password is OK */
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         rcDisconnect( Conn );
         exit( 7 );
     }

--- a/src/iphymv.cpp
+++ b/src/iphymv.cpp
@@ -5,11 +5,14 @@
  */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/phymvUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -80,6 +83,7 @@ main( int argc, char **argv ) {
     status = clientLogin( conn );
     if ( status != 0 ) {
         // Failed to authenticate as the configured user
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         return 3;
     }

--- a/src/ips.cpp
+++ b/src/ips.cpp
@@ -5,9 +5,12 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 int
 printProcStat( rodsArguments_t *myRodsArgs, genQueryOut_t *procStatOut );
@@ -69,6 +72,7 @@ main( int argc, char **argv ) {
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             return 7;
         }

--- a/src/iput.cpp
+++ b/src/iput.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/putUtil.h>
@@ -12,6 +13,8 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/irods_parse_command_line_options.hpp>
+
+#include <cstdio>
 
 void usage( FILE* );
 
@@ -83,6 +86,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         return 7;
     }

--- a/src/iqdel.cpp
+++ b/src/iqdel.cpp
@@ -2,6 +2,9 @@
 #include <irods/irods_pack_table.hpp>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
+
+#include <cstdio>
 
 #define MAX_SQL 300
 #define BIG_STR 200
@@ -94,6 +97,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         printError( Conn, status, "clientLogin" );
         if ( !debug ) {
             return 3;

--- a/src/iqmod.cpp
+++ b/src/iqmod.cpp
@@ -2,6 +2,9 @@
 #include <irods/irods_pack_table.hpp>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
+
+#include <cstdio>
 
 #define MAX_SQL 300
 #define BIG_STR 200
@@ -98,6 +101,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         printError( Conn, status, "clientLogin" );
         if ( !debug ) {
             return 3;

--- a/src/iqstat.cpp
+++ b/src/iqstat.cpp
@@ -4,6 +4,7 @@
 #include <irods/rcMisc.h>
 #include <irods/rods.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/rodsLog.h>
 #include <irods/user_administration.hpp>
 
@@ -175,6 +176,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         if ( !debug ) {
             return 3;
         }

--- a/src/iquest.cpp
+++ b/src/iquest.cpp
@@ -4,10 +4,12 @@
 #include <irods/parseCommandLine.h>
 #include <irods/rcMisc.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/rodsPath.h>
 
 #include <boost/format.hpp>
 
+#include <cstdio>
 #include <iostream>
 #include <string>
 
@@ -393,6 +395,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         return 3;
     }
 

--- a/src/iquota.cpp
+++ b/src/iquota.cpp
@@ -2,6 +2,9 @@
 #include <irods/irods_pack_table.hpp>
 #include <irods/rods.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
+
+#include <cstdio>
 
 #define BIG_STR 200
 #define QUOTA_APPROACH_WARNING_SIZE -10000000000LL
@@ -543,6 +546,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         if ( !debug ) {
             return 3;
         }

--- a/src/ireg.cpp
+++ b/src/ireg.cpp
@@ -3,7 +3,10 @@
 #include <irods/parseCommandLine.h>
 #include <irods/regUtil.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/rodsPath.h>
+
+#include <cstdio>
 
 void usage();
 
@@ -80,6 +83,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/irepl.cpp
+++ b/src/irepl.cpp
@@ -5,12 +5,15 @@
  */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/replUtil.h>
 #include <irods/rcGlobalExtern.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 #include <iostream>
 
 void usage();
@@ -88,6 +91,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/irm.cpp
+++ b/src/irm.cpp
@@ -5,11 +5,14 @@
  */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/rmUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -76,6 +79,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/irmdir.cpp
+++ b/src/irmdir.cpp
@@ -4,10 +4,13 @@
 #include <irods/rmdirUtil.h>
 #include <irods/rcMisc.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 
 #include <boost/program_options.hpp>
+
+#include <cstdio>
 
 void usage( char *prog );
 
@@ -119,6 +122,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         rcDisconnect( Conn );
         exit( 7 );
     }

--- a/src/irmtrash.cpp
+++ b/src/irmtrash.cpp
@@ -5,11 +5,14 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/rmtrashUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -74,6 +77,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/irsync.cpp
+++ b/src/irsync.cpp
@@ -5,11 +5,14 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/rsyncUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -115,6 +118,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/irule.cpp
+++ b/src/irule.cpp
@@ -3,6 +3,7 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/getUtil.h>
@@ -11,6 +12,8 @@
 #include <irods/irods_configuration_keywords.hpp>
 
 #include <boost/program_options.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -224,6 +227,7 @@ main( int argc, char **argv ) {
 
                 status = clientLogin( conn );
                 if ( status != 0 ) {
+                    print_error_stack_to_file(conn->rError, stderr);
                     rcDisconnect( conn );
                     exit( 7 );
                 }
@@ -438,6 +442,7 @@ main( int argc, char **argv ) {
 
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             exit( 7 );
         }

--- a/src/iscan.cpp
+++ b/src/iscan.cpp
@@ -4,9 +4,13 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/scanUtil.h>
+
+#include <cstdio>
+
 void usage();
 
 int
@@ -69,6 +73,7 @@ main( int argc, char **argv ) {
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             return 7;
         }

--- a/src/istream.cpp
+++ b/src/istream.cpp
@@ -1,4 +1,5 @@
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/client_connection.hpp>
 #include <irods/dstream.hpp>
 #include <irods/transport/default_transport.hpp>

--- a/src/isysmeta.cpp
+++ b/src/isysmeta.cpp
@@ -2,9 +2,12 @@
  *** For more information please refer to files in the COPYRIGHT directory ***/
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/data_object_modify_info.h>
+
+#include <cstdio>
 
 void usage();
 
@@ -375,6 +378,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         rcDisconnect( Conn );
         exit( 3 );
     }

--- a/src/iticket.cpp
+++ b/src/iticket.cpp
@@ -4,6 +4,7 @@
 #include <irods/rcMisc.h>
 #include <irods/rods.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/rodsPath.h>
 
 #include <boost/date_time.hpp>
@@ -861,6 +862,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         if ( !debug ) {
             return 3;
         }

--- a/src/itouch.cpp
+++ b/src/itouch.cpp
@@ -1,4 +1,5 @@
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/client_connection.hpp>
 #include <irods/irods_version.h>
 #include <irods/touch.h>

--- a/src/itrim.cpp
+++ b/src/itrim.cpp
@@ -5,11 +5,14 @@
 */
 
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/trimUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -78,6 +81,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/iunreg.cpp
+++ b/src/iunreg.cpp
@@ -1,10 +1,13 @@
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/trimUtil.h>
 #include <irods/rmUtil.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
+
+#include <cstdio>
 
 void usage();
 
@@ -73,6 +76,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(conn->rError, stderr);
         rcDisconnect( conn );
         exit( 7 );
     }

--- a/src/iuserinfo.cpp
+++ b/src/iuserinfo.cpp
@@ -3,8 +3,11 @@
 #include <irods/irods_query.hpp>
 #include <irods/rods.h>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 
 #include <boost/format.hpp>
+
+#include <cstdio>
 
 int debug = 0;
 
@@ -143,6 +146,7 @@ main( int argc, char **argv ) {
 
     status = clientLogin( Conn );
     if ( status != 0 ) {
+        print_error_stack_to_file(Conn->rError, stderr);
         if ( !debug ) {
             return 3;
         }

--- a/src/izonereport.cpp
+++ b/src/izonereport.cpp
@@ -4,14 +4,16 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/rodsClient.h>
+#include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
 #include <irods/rodsPath.h>
 #include <irods/lsUtil.h>
 #include <irods/irods_buffer_encryption.hpp>
 #include <irods/zone_report.h>
+
+#include <cstdio>
 #include <string>
 #include <iostream>
-
 
 void usage() {
     const char *msgs[] = {
@@ -89,6 +91,7 @@ main( int _argc, char** argv ) {
     if ( strcmp( myEnv.rodsUserName, PUBLIC_USER_NAME ) != 0 ) {
         status = clientLogin( conn );
         if ( status != 0 ) {
+            print_error_stack_to_file(conn->rError, stderr);
             rcDisconnect( conn );
             exit( 7 );
         }


### PR DESCRIPTION
The clientLogin function no longer prints an error. Instead client functions must print the error themselves on failed clientLogin.