### PR TITLE
[irods/irods#6412] Bump version number to 4.3.1. (main)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.7.0 FATAL_ERROR) #CPACK_DEBIAN_<COMPONENT>_PACK
 
 option(IRODS_ENABLE_ADDRESS_SANITIZER "Enables detection of memory leaks and other features provided by Address Sanitizer." OFF)
 
-find_package(IRODS 4.3.0 EXACT REQUIRED CONFIG)
+find_package(IRODS 4.3.1 EXACT REQUIRED CONFIG)
 set(IRODS_PACKAGE_PREFIX "${PACKAGE_PREFIX_DIR}")
 
-set(IRODS_PACKAGE_REVISION "1")
+set(IRODS_PACKAGE_REVISION "0")
 
 include(RequireOutOfSourceBuild)
 include(IrodsCXXCompiler)


### PR DESCRIPTION
In service of irods/irods#6412

Cherry-picked from #417 

Companion PR: https://github.com/irods/irods/pull/7394

I imagine this will be changed very soon due to irods/irods#7361?