### PR TITLE
[irods/irods#7421] irm: expand docs force option (4-3-stable)

### DIFF
--- a/src/irm.cpp
+++ b/src/irm.cpp
@@ -122,6 +122,7 @@ usage() {
         " ",
         "Options are:",
         " -f  force - Immediate removal of data objects without putting them in trash.",
+        "             Ignores non-existent data objects and collections.",
         " -r  recursive - Recursively remove the target collection, all data objects in the ",
         "                 collection, and all subcollections.",
         " -v  verbose",


### PR DESCRIPTION
Note that this option makes irm ignore non-existent data objects.