### PR TITLE
[irods/irods#7220] Do not explicitly build against libc++ (main)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,6 @@ endif()
 
 set(IRODS_BUILD_WITH_WERROR ${IRODS_BUILD_WITH_WERROR_DEFAULT} CACHE BOOL "Choose whether to compile with -Werror.")
 
-include(UseLibCXX)
-
 find_package(nlohmann_json "3.6.1" REQUIRED)
 find_package(fmt "8.1.1"
   HINTS "${IRODS_EXTERNALS_FULLPATH_FMT}")


### PR DESCRIPTION
In service of irods/irods#7220

Merge irods/irods#7526 before merging this.