### PR TITLE
[irods/irods#7531] bump irods version requirement and allow usage of find modules (4-3-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7.0 FATAL_ERROR) #CPACK_DEBIAN_<COMPONENT>_PACK
 
 option(IRODS_ENABLE_ADDRESS_SANITIZER "Enables detection of memory leaks and other features provided by Address Sanitizer." OFF)
 
-find_package(IRODS 4.3.1 EXACT REQUIRED CONFIG)
+find_package(IRODS 4.3.2 EXACT REQUIRED)
 set(IRODS_PACKAGE_PREFIX "${PACKAGE_PREFIX_DIR}")
 
 set(IRODS_PACKAGE_REVISION "0")


### PR DESCRIPTION
In service of irods/irods#7531

Not removing `EXACT` from the `find_package(IRODS` call since the icommands are currently pretty tightly coupled to the irods version they target.

Merge irods/irods#7536 before merging this.