### PR TITLE
[irods/irods#7470] Ensure icommands set SP_OPTION (main)

### DIFF
--- a/src/ierror.cpp
+++ b/src/ierror.cpp
@@ -8,6 +8,7 @@ void usage( char *prog );
 
 int
 main( int argc, char **argv ) {
+    set_ips_display_name("ierror");
 
     signal( SIGPIPE, SIG_IGN );
 

--- a/src/iget.cpp
+++ b/src/iget.cpp
@@ -10,6 +10,7 @@
 #include <irods/rodsPath.h>
 #include <irods/getUtil.h>
 #include <irods/rcGlobalExtern.h>
+#include <irods/rcMisc.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/irods_parse_command_line_options.hpp>
@@ -20,6 +21,7 @@ void usage( FILE* );
 
 int
 main( int argc, char **argv ) {
+    set_ips_display_name("iget");
 
     signal( SIGPIPE, SIG_IGN );
 

--- a/src/iput.cpp
+++ b/src/iput.cpp
@@ -10,6 +10,7 @@
 #include <irods/rodsPath.h>
 #include <irods/putUtil.h>
 #include <irods/rcGlobalExtern.h>
+#include <irods/rcMisc.h>
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/irods_parse_command_line_options.hpp>
@@ -20,6 +21,7 @@ void usage( FILE* );
 
 int
 main( int argc, char **argv ) {
+    set_ips_display_name("iput");
 
     signal( SIGPIPE, SIG_IGN );
 

--- a/src/irmdir.cpp
+++ b/src/irmdir.cpp
@@ -80,6 +80,7 @@ parse_program_options(
 
 int
 main( int argc, char **argv ) {
+    set_ips_display_name("irmdir");
     signal( SIGPIPE, SIG_IGN );
 
     int status;

--- a/src/irule.cpp
+++ b/src/irule.cpp
@@ -10,6 +10,7 @@
 #include <irods/irods_client_api_table.hpp>
 #include <irods/irods_pack_table.hpp>
 #include <irods/irods_configuration_keywords.hpp>
+#include <irods/rcMisc.h>
 
 #include <boost/program_options.hpp>
 
@@ -134,6 +135,7 @@ irods::error parseProgramOptions(
 
 int
 main( int argc, char **argv ) {
+    set_ips_display_name("irule");
 
     signal( SIGPIPE, SIG_IGN );
 

--- a/src/itree.cpp
+++ b/src/itree.cpp
@@ -51,6 +51,7 @@ static std::uintmax_t total_size = 0;
 
 
 int main(int argc, char** argv){
+    set_ips_display_name("itree");
     po::options_description desc{""};
     po::positional_options_description pod;
     pod.add("dir",1);


### PR DESCRIPTION
Ensure that all icommands set `SP_OPTION`. Used `set_ips_display_name(...)` for additional warning log if an error occurs.