### PR TITLE
[irods/irods#7592] Fix centos 7 build against libstdc++ with new externals (4-3-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,25 @@ foreach(EXECUTABLE ${IRODS_CLIENT_ICOMMANDS_EXECUTABLES})
   endif()
 endforeach()
 
+# Fix build on EL7
+if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos" AND IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "7" AND NOT IRODS_BUILD_AGAINST_LIBCXX)
+  set(
+    ICOMMANDS_NEEDING_OVERLINK
+    ierror
+    ienv
+    ipwd
+  )
+  if (CMAKE_VERSION VERSION_LESS "3.13.0")
+    foreach(overlink_target IN LISTS ICOMMANDS_NEEDING_OVERLINK)
+      set_property(TARGET ${overlink_target} APPEND PROPERTY LINK_FLAGS "-Wl,--no-as-needed")
+    endforeach()
+  else()
+    foreach(overlink_target IN LISTS ICOMMANDS_NEEDING_OVERLINK)
+      target_link_options(${overlink_target} PRIVATE "LINKER:--no-as-needed")
+    endforeach()
+  endif()
+endif()
+
 set(
   IRODS_CLIENT_ICOMMANDS_SCRIPTS
   igetwild


### PR DESCRIPTION
4-3-stable version of #477

In service of irods/irods#7592

With the updated externals from irods/externals#246, building `ierror`, `ienv`, and `ipwd` against libstdc++ fails on Centos 7 with the following error:
```
/opt/rh/devtoolset-10/root/usr/lib/gcc/x86_64-redhat-linux/10/../../../../bin/ld: /opt/rh/devtoolset-10/root/usr/lib/gcc/x86_64-redhat-linux/10/libstdc++_nonshared.a(system_error48.o): undefined reference to symbol '__cxa_free_exception@@CXXABI_1.3'
/opt/rh/devtoolset-10/root/usr/lib/gcc/x86_64-redhat-linux/10/../../../../bin/ld: /usr/lib64/libstdc++.so.6: error adding symbols: DSO missing from command line
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
```

I'm not sure what changed to cause this to happen, but passing `--no-as-needed` to the linker fixes it.

This PR does not need to wait on any other PRs before being merged.