### PR TITLE
[#7761] Fix help text for itree JSON option (4-3-stable)

### DIFF
--- a/src/itree.cpp
+++ b/src/itree.cpp
@@ -361,7 +361,7 @@ Options:
       --indent=INTEGER
                   The number of spaces used for indenting nested collections.
                   (defaults to 2).
-  -j, --json      Print collection tree as JSON.
+  -J, --json      Print collection tree as JSON.
   -L, --depth=INTEGER
                   Limit the depth of the listing (defaults to 1000).
   -p, --pattern-regex=PATTERN


### PR DESCRIPTION
This doesn't require testing. It's just help text.

I opened an issue for test coverage. See irods/irods#7825. We'll handle that post 4.3.3.