### PR TITLE
[irods/irods8082] Do not display stacktrace on exception (4-3-stable)

### DIFF
--- a/src/itree.cpp
+++ b/src/itree.cpp
@@ -144,6 +144,10 @@ int main(int argc, char** argv){
             print_dir(path, vm, conn);
         }
     }
+    catch (const irods::exception& e) {
+        std::cerr << "Error: " << e.client_display_what() << "\n";
+        return 1;
+    }
     catch (const std::exception& e) {
         std::cerr << "Error:" << e.what() << "\n";
         return 1;


### PR DESCRIPTION
Cherry-pick of https://github.com/irods/irods_client_icommands/pull/524