### PR TITLE
[irods/irods#8090] Cherry-pick: Add Undefined Behavior Sanitizer Option to CMake (main)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.7.0 FATAL_ERROR) #CPACK_DEBIAN_<COMPONENT>_PACKAGE_NAME
 
 option(IRODS_ENABLE_ADDRESS_SANITIZER "Enables detection of memory leaks and other features provided by Address Sanitizer." OFF)
+option(IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER "Enables detection of undefined behavior provided by Undefined Behavior Sanitizer." OFF)
+option(IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER_IMPLICIT_CONVERSION_CHECK "Enables detection of implicit conversions by Undefined Behavior Sanitizer." OFF)
 
 find_package(IRODS 4.90.0 EXACT REQUIRED)
 set(IRODS_PACKAGE_PREFIX "${PACKAGE_PREFIX_DIR}")
@@ -18,18 +20,39 @@ set(CMAKE_EXE_LINKER_FLAGS_RELEASE_INIT "-Wl,--gc-sections -Wl,-z,combreloc")
 include(IrodsRunpathDefaults)
 
 if (IRODS_ENABLE_ADDRESS_SANITIZER)
+  add_compile_options(-fsanitize=address)
+  add_link_options(-fsanitize=address)
+endif()
+
+if (IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER)
   add_compile_options(
-    -fsanitize=address
-    -fno-omit-frame-pointer
-    -fno-optimize-sibling-calls
-    -O1
-  )
+    -fsanitize=undefined
+    -fsanitize=float-divide-by-zero
+    -fsanitize=unsigned-integer-overflow
+    -fsanitize=local-bounds
+    -fsanitize=nullability
+    -fsanitize-ignorelist=${CMAKE_CURRENT_SOURCE_DIR}/ub-sanitizer-ignorelist.txt)
   add_link_options(
-    -fsanitize=address
+    -fsanitize=undefined
+    -fsanitize=float-divide-by-zero
+    -fsanitize=unsigned-integer-overflow
+    -fsanitize=local-bounds
+    -fsanitize=nullability)
+  if (IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER_IMPLICIT_CONVERSION_CHECK)
+     add_compile_options(-fsanitize=implicit-conversion)
+     add_link_options(-fsanitize=implicit-conversion)
+  endif()
+endif()
+
+if (IRODS_ENABLE_ADDRESS_SANITIZER OR IRODS_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER)
+  add_compile_options(
     -fno-omit-frame-pointer
     -fno-optimize-sibling-calls
-    -O1
-  )
+    -O1)
+  add_link_options(
+    -fno-omit-frame-pointer
+    -fno-optimize-sibling-calls
+    -O1)
 else()
   set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS_INIT} -Wl,-z,defs")
 endif()

--- a/ub-sanitizer-ignorelist.txt
+++ b/ub-sanitizer-ignorelist.txt
@@ -1,0 +1,1 @@
+src:/opt/irods-externals/*


### PR DESCRIPTION
Cherry-pick of #518, compainion to irods/irods#8168.

No changes needed to cherry-pick.

---

This commit allows for the enabling of the Undefined Behavior Sanitizer (UBSAN). Nearly all of the options provided by UBSAN are enabled by default, with the exception of implicit conversions. A separate option exists to optionally enable implicit conversion checks.