### PR TITLE
[irods/irods#7985] Remove test containing `msiAclPolicy` (main)

### DIFF
--- a/test/rules/rulemsiAclPolicy.r
+++ b/test/rules/rulemsiAclPolicy.r
@@ -1,1 +1,0 @@
-acAclPolicy { msiAclPolicy("STRICT"); }


### PR DESCRIPTION
Issue quick link: irods/irods#7985.

Companion to PR: irods/irods#8264.

This PR just removes a test containing `msiAclPolicy`.