### PR TITLE
[irods/irods#7578] Remove `--link` from help text (main)

### DIFF
--- a/src/iput.cpp
+++ b/src/iput.cpp
@@ -196,7 +196,6 @@ usage( FILE* _fout ) {
         "       it in the catalog.",
         " -K  verify checksum - calculate and verify the checksum on the data, both",
         "       client-side and server-side, and store it in the catalog.",
-        " --link - [Deprecated] ignore symlinks. Use --ignore-symlinks.",
         " --ignore-symlinks - ignore symlinks.",
         " -n  replNum  - the replica to be replaced, typically not needed",
         " -N  numThreads - the number of threads to use for the transfer. A value of",

--- a/src/irsync.cpp
+++ b/src/irsync.cpp
@@ -214,7 +214,6 @@ usage() {
         " -l  lists all the source files that needs to be synchronized",
         "       (including their filesize in bytes) with respect to the target",
         "       without actually doing the synchronization.",
-        " --link - [Deprecated] ignore symlinks. Use --ignore-symlinks.",
         " --ignore-symlinks - ignore symlinks. Valid only for syncing from local host to",
         "        iRODS.",
         " -a   synchronize to all replicas if the target is an iRODS data object/collection.",


### PR DESCRIPTION
Issue Quick Link: irods/irods#7578
Companion PR: irods/irods#8323

This PR removes the help text for `--link`, which is removed in the companion PR.