### PR TITLE
[irods/irods#7594] Remove mentions of backup mode in icommands (main)

### DIFF
--- a/src/irepl.cpp
+++ b/src/irepl.cpp
@@ -33,7 +33,7 @@ main( int argc, char **argv ) {
     int reconnFlag;
 
 
-    optStr = "aBG:MN:hrvVn:PR:S:TX:UZ"; // JMC - backport 4549
+    optStr = "aG:MN:hrvVn:PR:S:TX:UZ"; // JMC - backport 4549
 
     status = parseCmdLineOpt( argc, argv, optStr, 1, &myRodsArgs ); // JMC - backport 4549
 
@@ -118,7 +118,7 @@ void
 usage() {
 
     char *msgs[] = {
-        "Usage: irepl [-aBMPrTvV] [-n replNum] [-R destResource] [-S srcResource]",
+        "Usage: irepl [-aMPrTvV] [-n replNum] [-R destResource] [-S srcResource]",
         "[-N numThreads] [-X restartFile] [--purgec]  [--rlock]dataObj|collection ... ",
         " ",
         "Replicate a file in iRODS to another storage resource.",
@@ -152,8 +152,6 @@ usage() {
         " ",
         "Options are:",
         " -a  all - if used with -U, update all stale copies",
-        " -B  Backup mode - [Deprecated] if a good copy already exists in this",
-        "     resource, don't make another copy.",
         " -P  output the progress of the replication.",
         " -U  Update (Synchronize) an old replica with the latest copy. (see -a)",
         " -M  admin - admin user uses this option to backup/replicate other users files",

--- a/test/rules/rulemsiDataObjRepl.r
+++ b/test/rules/rulemsiDataObjRepl.r
@@ -3,7 +3,6 @@ myTestRule {
 #  Data Object path
 #  Optional flags in form keyword=value
 #    destRescName - the target resource for the replica
-#    backupRescName - specifies use of the resource for the backup mode
 #    rescName - the resource holding the source data
 #    updateRepl= - specifies all replicas will be updated
 #    replNum - specifies the replica number to use as the source


### PR DESCRIPTION
Issue quick link: irods/irods#7594
Companion PR: irods/irods#8340

This PR removes help text on backup mode, as well as removes `B` from the optStr.