### PR TITLE
[8622] Make iadmin quota GenQuery use the same query conditions (main)

### DIFF
--- a/src/iadmin.cpp
+++ b/src/iadmin.cpp
@@ -967,7 +967,7 @@ auto show_resource_quotas(const char* _user_or_group = nullptr) -> int
 
         const auto query_string_template = fmt::format(
             FMT_COMPILE(
-                "select {} where QUOTA_USER_NAME = '{{}}' and QUOTA_USER_ZONE = '{{}}' and QUOTA_RESC_NAME != '0'"),
+                "select {} where QUOTA_USER_NAME = '{{}}' and QUOTA_USER_ZONE = '{{}}' and QUOTA_RESC_ID != '0'"),
             fmt::join(columns, ", "));
 
         print_genquery_results(fmt::format(fmt::runtime(query_string_template), user_name, zone_name), labels);


### PR DESCRIPTION
Quick fix. `test_quotas` passes.
Should I run the full test suite, or do we trust that `test_quotas` is enough to determine that it's good? From what I can tell, `test_quotas` is the only thing that ever calls `iadmin lq`.