### PR TITLE
[irods/irods#8272] Deprecate advisory lock options: --wlock, --rlock (4-3-stable)

### DIFF
--- a/src/iget.cpp
+++ b/src/iget.cpp
@@ -1,9 +1,3 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/*
- * iget - The irods get utility
-*/
-
 #include <irods/rodsClient.h>
 #include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
@@ -178,7 +172,6 @@ usage( FILE* _fout ) {
         "sockets getting timed out by the firewall as reported by some users.",
         " ",
         "Options are:",
-
         " -f  force - write local files even it they exist already (overwrite them)",
         " -I  redirect connection - redirect the connection to connect directly",
         "       to the best (determined by the first 10 data objects in the input",
@@ -207,7 +200,7 @@ usage( FILE* _fout ) {
         "      on and the lfRestartFile input specifies a local file that contains",
         "      the restart info.",
         " -t  ticket - ticket (string) to use for ticket-based access.",
-        " --rlock - use advisory read lock for the download",
+        " --rlock - [Deprecated] use advisory read lock for the download",
         " --kv_pass - pass quoted key-value strings through to the resource hierarchy,",
         "             of the form key1=value1;key2=value2",
         " -h  this help",

--- a/src/iput.cpp
+++ b/src/iput.cpp
@@ -1,9 +1,3 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/*
- * iput - The irods put utility
-*/
-
 #include <irods/rodsClient.h>
 #include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
@@ -222,7 +216,7 @@ usage( FILE* _fout ) {
         " --lfrestart lfRestartFile - specifies that the large file restart option is",
         "       on and the lfRestartFile input specifies a local file that contains",
         "       the restart information.",
-        " --wlock - use advisory write (exclusive) lock for the upload",
+        " --wlock - [Deprecated] use advisory write (exclusive) lock for the upload",
         " --kv_pass - pass quoted key-value strings through to the resource hierarchy,",
         "             of the form key1=value1;key2=value2",
         " --metadata - atomically assign metadata after a data object is registered in",

--- a/src/irepl.cpp
+++ b/src/irepl.cpp
@@ -1,9 +1,3 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/*
- * irepl - The irods repl utility
- */
-
 #include <irods/rodsClient.h>
 #include <irods/rodsError.h>
 #include <irods/parseCommandLine.h>
@@ -194,7 +188,7 @@ usage() {
         "     restartFile input specifies a local file that contains the restart info.",
         " --purgec  Purge the staged cache copy after replicating an object to a",
         "     COMPOUND resource",
-        " --rlock - use advisory read lock for the replication",
+        " --rlock - [Deprecated] use advisory read lock for the replication",
         " -h  this help",
         " ",
         "Also see 'irsync' for other types of iRODS/local synchronization.",


### PR DESCRIPTION
Companion PR: https://github.com/irods/irods/pull/8847